### PR TITLE
Feature: Environment variables

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pyyaml = "~=5.3.1"
 requests = "~=2.25.1"
 boto3 = "~=1.16.51"
 loguru = "~=0.5.3"
+jinja2 = "==2.11.2"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -222,7 +222,7 @@
                 "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7",
                 "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==5.3.1"
         },
         "flake8": {
@@ -253,7 +253,7 @@
                 "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e",
                 "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.7.0"
         },
         "mccabe": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85cb6fe43d46174d1124c843e63d8e0beac2dda5840948b27666bca71b7618ec"
+            "sha256": "e97e252abad1d5a177bbc794a0cea4ddacbff6813e719ca29aa2f69ef5fdd1dc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -62,6 +62,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
+        "jinja2": {
+            "hashes": [
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+            ],
+            "index": "pypi",
+            "version": "==2.11.2"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
@@ -77,6 +85,45 @@
             ],
             "index": "pypi",
             "version": "==0.5.3"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -222,7 +269,7 @@
                 "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7",
                 "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.3.1"
         },
         "flake8": {
@@ -253,7 +300,7 @@
                 "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e",
                 "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.7.0"
         },
         "mccabe": {

--- a/README.md
+++ b/README.md
@@ -37,16 +37,25 @@ retention_days: 7
 
 ## Environment Variables
 
-To include environment variables it's possible to use jinja2 rendering tags like so
+The `config.yaml` will ✨ **magically interpolate** ✨ any environment variables that exist in the environment where `blackbox` is running. This is very useful if you want to keep your secrets in environment variables, instead of keeping them in the config file in plaintext.
 
-```sh
-export MONGO_USERNAME=someusername
-export MONGO_PASSWORD=somepassword
+#### Example
+Imagine your current config looks like this, but you want to move the username and password into environment variables.
+```yaml
+databases:
+  - mongodb://lemonsaurus:security-is-overrated@mongo.lemonsaur.us:1234
 ```
 
-```jinja
+So we'll create two environment variables like these:
+```sh
+export MONGO_USERNAME=lemonsaurus
+export MONGO_PASSWORD=security-is-overrated
+```
+
+And now we can make use of these environment variables by using double curly brackets, like this:
+```yaml
 databases:
-  - mongodb://{{ MONGO_USERNAME }}:{{ MONGO_PASSWORD }}@host:port
+  - mongodb://{{ MONGO_USERNAME }}:{{ MONGO_PASSWORD }}@mongo.lemonsaur.us:1234
 ```
 
 ## Databases

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ notifiers:
 retention_days: 7
 ```
 
+## Environment Variables
+
+To include environment variables it's possible to use jinja2 rendering tags like so
+
+```sh
+export MONGO_USERNAME=someusername
+export MONGO_PASSWORD=somepassword
+```
+
+```jinja
+databases:
+  - mongodb://{{ MONGO_USERNAME }}:{{ MONGO_PASSWORD }}@host:port
+```
+
 ## Databases
 Right now, this app supports **MongoDB**, **PostgreSQL 12** and **Redis**. If you need support for an additional database, consider opening a pull request to add a new database handler.
 
@@ -78,7 +92,7 @@ If you want to re-enable `appendonly`:
 ### S3
 We support any S3 object storage bucket, whether it's from **AWS**, **Linode**, **DigitalOcean**, **Scaleway**, or another S3-compatible object storage provider.
 
-**Blackbox** will respect the `retention_days` configuration setting and delete older files from the S3 storage. Please note that if you have a bucket expiration policy on your storage, **blackbox** will not do anything to disable it. So, for example, if your bucket expiration policy is 12 hours and blackbox is set to 7 `retention_days`, then your backups are all gonna be deleted after 12 hours unless you disable your policy.  
+**Blackbox** will respect the `retention_days` configuration setting and delete older files from the S3 storage. Please note that if you have a bucket expiration policy on your storage, **blackbox** will not do anything to disable it. So, for example, if your bucket expiration policy is 12 hours and blackbox is set to 7 `retention_days`, then your backups are all gonna be deleted after 12 hours unless you disable your policy.
 
 #### Connection string
 ```json
@@ -103,7 +117,7 @@ To upload stuff to S3, you'll need credentials. Your **AWS credentials** can be 
 ![blackbox](img/blackbox_discord_2.png)
 
 ### Discord
-To set this up, simply add a valid Discord webhook URL to the `notifiers` list. 
+To set this up, simply add a valid Discord webhook URL to the `notifiers` list.
 
 These usually look something like `https://discord.com/api/webhooks/797541821394714674/lzRM9DFggtfHZXGJTz3yE-MrYJ-4O-0AbdQg3uV2x4vFbu7HTHY2Njq8cx8oyMg0T3Wk`, but we also support `ptb.discord.com` and `canary.discord.com` webhooks.
 

--- a/blackbox/utils/yaml.py
+++ b/blackbox/utils/yaml.py
@@ -17,7 +17,11 @@ def get_yaml_config() -> dict:
 
     try:
         with open(root_folder / "config.yaml", encoding="UTF-8", mode="r") as f:
-            return yaml.safe_load(template.from_string(f.read()).render(**os.environ))
+            # Inject the local environment variables into the rendering context.
+            # This bit of magic allows us to resolve any {{ VARIABLE }} to whatever
+            # the value of the equivalent environment variable is.
+            parsed_config = template.from_string(f.read()).render(**os.environ)
+            return yaml.safe_load(parsed_config)
 
     except TemplateSyntaxError as e:
         raise ImproperlyConfigured(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,12 @@ def config_file(mocker):
         """
     )
 
-    os.environ["MONGO_USER"] = "mongouser"
-    os.environ["MONGO_PW"] = "mongopassword"
+    environment_variables = {
+        "MONGO_USER": "mongouser",
+        "MONGO_PW": "mongopassword"
+    }
+
+    mocker.patch.dict(os.environ, environment_variables)
 
     mocker.patch("builtins.open", mocker.mock_open(read_data=config))
 
@@ -42,7 +46,11 @@ def config_file_with_errors(mocker):
         """
     )
 
-    os.environ["MONGO_USER"] = "mongouser"
+    environment_variables = {
+        "MONGO_USER": "mongouser",
+    }
+
+    mocker.patch.dict(os.environ, environment_variables)
 
     mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))
 
@@ -57,9 +65,5 @@ def config_file_with_missing_value(mocker):
             - mongodb://{{ MONGO_USER }} :mongopassword@host:port
         """
     )
-
-    # Ensure the value is unset to cause expected error
-    if os.environ.get("MONGO_USER"):
-        del os.environ["MONGO_USER"]
 
     mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # This is a special pytest file
-
+import os
 from textwrap import dedent
 
 import pytest
@@ -12,7 +12,7 @@ def config_file(mocker):
     config = dedent(
         """
         databases:
-            - mongodb://username:password@host:port
+            - mongodb://{{ MONGO_USER }}:{{ MONGO_PW }}@host:port
             - postgres://username:password@host:port
 
         storage:
@@ -25,4 +25,41 @@ def config_file(mocker):
         """
     )
 
-    mocker.patch('builtins.open', mocker.mock_open(read_data=config))
+    os.environ["MONGO_USER"] = "mongouser"
+    os.environ["MONGO_PW"] = "mongopassword"
+
+    mocker.patch("builtins.open", mocker.mock_open(read_data=config))
+
+
+@pytest.fixture
+def config_file_with_errors(mocker):
+    """ Mock reading config values"""
+
+    config_with_missing_bracket = dedent(
+        """
+        databases:
+            - mongodb://{{ MONGO_USER} :mongopassword@host:port
+        """
+    )
+
+    os.environ["MONGO_USER"] = "mongouser"
+
+    mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))
+
+
+@pytest.fixture
+def config_file_with_missing_value(mocker):
+    """ Mock reading config values"""
+
+    config_with_missing_bracket = dedent(
+        """
+        databases:
+            - mongodb://{{ MONGO_USER }} :mongopassword@host:port
+        """
+    )
+
+    # Ensure the value is unset to cause expected error
+    if os.environ.get("MONGO_USER"):
+        del os.environ["MONGO_USER"]
+
+    mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 
 def test_config_gets_correct_values(config_file):
     """Test if the YAMLGetter class gets the values we expect it to get."""
@@ -13,3 +15,30 @@ def test_config_gets_correct_values(config_file):
     for name, value in Blackbox:
         if name in _config:
             assert _config[name] == value
+
+
+def test_config_render_fails(config_file_with_errors):
+    """Test if the YAMLGetter class gets the values we expect it to get."""
+
+    # The blackbox package needs to be imported after patching open()
+    # because the get_yaml_config() is called implicitly at package import
+    # that's why these imports are here
+    from blackbox.exceptions import ImproperlyConfigured
+    from blackbox.utils.yaml import get_yaml_config
+
+    with pytest.raises(ImproperlyConfigured):
+        get_yaml_config()
+
+
+def test_config_missing_value(config_file_with_missing_value):
+    """Test if the YAMLGetter class gets the values we expect it to get."""
+
+    # The blackbox package needs to be imported after patching open()
+    # because the get_yaml_config() is called implicitly at package import
+    # that's why these imports are here
+
+    from blackbox.exceptions import ImproperlyConfigured
+    from blackbox.utils.yaml import get_yaml_config
+
+    with pytest.raises(ImproperlyConfigured):
+        get_yaml_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 import pytest
 
+from blackbox.exceptions import ImproperlyConfigured
+
 
 def test_config_gets_correct_values(config_file):
     """Test if the YAMLGetter class gets the values we expect it to get."""
@@ -23,7 +25,7 @@ def test_config_render_fails(config_file_with_errors):
     # The blackbox package needs to be imported after patching open()
     # because the get_yaml_config() is called implicitly at package import
     # that's why these imports are here
-    from blackbox.exceptions import ImproperlyConfigured
+
     from blackbox.utils.yaml import get_yaml_config
 
     with pytest.raises(ImproperlyConfigured):
@@ -37,7 +39,6 @@ def test_config_missing_value(config_file_with_missing_value):
     # because the get_yaml_config() is called implicitly at package import
     # that's why these imports are here
 
-    from blackbox.exceptions import ImproperlyConfigured
     from blackbox.utils.yaml import get_yaml_config
 
     with pytest.raises(ImproperlyConfigured):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,13 +2,14 @@ import pytest
 
 from blackbox.exceptions import ImproperlyConfigured
 
+# There are imports inside the test functions because
+# the blackbox package needs to be imported after patching open()
+# as the get_yaml_config() is called implicitly at package import
+
 
 def test_config_gets_correct_values(config_file):
     """Test if the YAMLGetter class gets the values we expect it to get."""
 
-    # The blackbox package needs to be imported after patching open()
-    # because the get_yaml_config() is called implicitly at package import
-    # that's why these imports are here
     from blackbox.config import Blackbox
     from blackbox.utils.yaml import get_yaml_config
 
@@ -22,10 +23,6 @@ def test_config_gets_correct_values(config_file):
 def test_config_render_fails(config_file_with_errors):
     """Test if the YAMLGetter class gets the values we expect it to get."""
 
-    # The blackbox package needs to be imported after patching open()
-    # because the get_yaml_config() is called implicitly at package import
-    # that's why these imports are here
-
     from blackbox.utils.yaml import get_yaml_config
 
     with pytest.raises(ImproperlyConfigured):
@@ -34,10 +31,6 @@ def test_config_render_fails(config_file_with_errors):
 
 def test_config_missing_value(config_file_with_missing_value):
     """Test if the YAMLGetter class gets the values we expect it to get."""
-
-    # The blackbox package needs to be imported after patching open()
-    # because the get_yaml_config() is called implicitly at package import
-    # that's why these imports are here
 
     from blackbox.utils.yaml import get_yaml_config
 


### PR DESCRIPTION
This PR adds the ability to inject environment variables into the configuration file using Jinja2 in-line variable tags

```jinja
databases:
  - mongodb://{{ MONGO_USERNAME }}:{{ MONGO_PASSWORD }}@host:port
```

closes #20 