### PR TITLE
integration test of mongodb backup call

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pytest-cov = "*"
 pytest-mock = "*"
 flake8 = "*"
 flake8-isort = "*"
+pytest-subprocess = "*"
 
 [packages]
 pyyaml = "~=5.3.1"
@@ -25,3 +26,4 @@ python_version = "3.9"
 test = "pytest --cov blackbox -vv --cov-report=term-missing ."
 lint = "flake8 ."
 isort = "isort ."
+html = "pytest --cov blackbox --cov-report=html ."

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e97e252abad1d5a177bbc794a0cea4ddacbff6813e719ca29aa2f69ef5fdd1dc"
+            "sha256": "8869dd51a9b416319b9121360722fc126f613f499f1db1e629155bab4bb6d978"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -381,6 +381,14 @@
             ],
             "index": "pypi",
             "version": "==3.5.1"
+        },
+        "pytest-subprocess": {
+            "hashes": [
+                "sha256:aa657f848d5fe5c15bd36b7f17309e5670582f2f1e2c72700574e3b6ffbb8deb",
+                "sha256:af5a87ad5894bae12c6a9b93cf32df58a25ec288c0581d100baa822976673a4a"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
         },
         "testfixtures": {
             "hashes": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,21 @@ def config_file_with_missing_value(mocker):
     config_with_missing_bracket = dedent(
         """
         databases:
+            - postgres://johnwasafraid
+            - postgres://lellowmelon
+        """
+    )
+
+    mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))
+
+
+@pytest.fixture
+def config_file_too_many_postgres(mocker):
+    """ Mock reading config values"""
+
+    config_with_missing_bracket = dedent(
+        """
+        databases:
             - mongodb://{{ MONGO_USER }} :mongopassword@host:port
         """
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,10 @@ def config_file_with_errors(mocker):
 
 
 @pytest.fixture
-def config_file_with_missing_value(mocker):
+def config_file_too_many_postgres(mocker):
     """ Mock reading config values"""
 
-    config_with_missing_bracket = dedent(
+    too_many_postgres = dedent(
         """
         databases:
             - postgres://johnwasafraid
@@ -67,18 +67,18 @@ def config_file_with_missing_value(mocker):
         """
     )
 
-    mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))
+    mocker.patch("builtins.open", mocker.mock_open(read_data=too_many_postgres))
 
 
 @pytest.fixture
-def config_file_too_many_postgres(mocker):
+def config_file_with_missing_value(mocker):
     """ Mock reading config values"""
 
-    config_with_missing_bracket = dedent(
+    missing_value = dedent(
         """
         databases:
             - mongodb://{{ MONGO_USER }} :mongopassword@host:port
         """
     )
 
-    mocker.patch("builtins.open", mocker.mock_open(read_data=config_with_missing_bracket))
+    mocker.patch("builtins.open", mocker.mock_open(read_data=missing_value))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,21 +56,6 @@ def config_file_with_errors(mocker):
 
 
 @pytest.fixture
-def config_file_too_many_postgres(mocker):
-    """ Mock reading config values"""
-
-    too_many_postgres = dedent(
-        """
-        databases:
-            - postgres://johnwasafraid
-            - postgres://lellowmelon
-        """
-    )
-
-    mocker.patch("builtins.open", mocker.mock_open(read_data=too_many_postgres))
-
-
-@pytest.fixture
 def config_file_with_missing_value(mocker):
     """ Mock reading config values"""
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,14 +1,6 @@
 import pytest
 
 
-def test_mongodb_handler_can_be_instantiated(config_file):
-    """Test if the MongoDB database handler can be instantiated."""
-
-    from blackbox.handlers.databases import MongoDB
-
-    MongoDB()
-
-
 def test_postgres_handler_can_be_instantiated_with_one_connstring(config_file):
     """Test if the PostgreSQL database handler can be instantiated."""
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,32 +1,22 @@
 import pytest
 
+from blackbox.exceptions import ImproperlyConfigured
+from blackbox.handlers.databases import Postgres
+from blackbox.handlers.databases import Redis
+
 
 def test_postgres_handler_can_be_instantiated_with_one_connstring(config_file):
     """Test if the PostgreSQL database handler can be instantiated."""
-
-    from blackbox.handlers.databases import Postgres
-
     Postgres()
 
 
-def test_postgres_fails_with_multiple_connstrings(config_file):
+def test_postgres_fails_with_multiple_connstrings(config_file_too_many_postgres):
     """Test if the PostgreSQL database handler can be instantiated with multiple connstrings."""
-
-    from blackbox.config import Blackbox
-    from blackbox.exceptions import ImproperlyConfigured
-    from blackbox.handlers.databases import Postgres
-
     with pytest.raises(ImproperlyConfigured):
-        Blackbox.databases = [
-            "postgres://johnwasafraid",
-            "postgres://lellowmelon"
-        ]
         Postgres()
 
 
 def test_redis_handler_can_be_instantiated(config_file):
     """Test if the Redis database handler can be instantiated."""
-
-    from blackbox.handlers.databases import Redis
 
     Redis()

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,5 +1,6 @@
 import pytest
 
+from blackbox.config import Blackbox
 from blackbox.exceptions import ImproperlyConfigured
 from blackbox.handlers.databases import Postgres
 from blackbox.handlers.databases import Redis
@@ -10,8 +11,11 @@ def test_postgres_handler_can_be_instantiated_with_one_connstring(config_file):
     Postgres()
 
 
-def test_postgres_fails_with_multiple_connstrings(config_file_too_many_postgres):
+def test_postgres_fails_with_multiple_connstrings(config_file):
     """Test if the PostgreSQL database handler can be instantiated with multiple connstrings."""
+
+    Blackbox.databases.append("postgres:/blabla")
+
     with pytest.raises(ImproperlyConfigured):
         Postgres()
 

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -1,11 +1,11 @@
 import datetime
 from pathlib import Path
 
+from blackbox.handlers.databases import MongoDB
+
 
 def test_mongodb_backup(config_file, mocker, fake_process):
     """Test if the MongoDB database handler executes a backup"""
-
-    from blackbox.handlers.databases import MongoDB
 
     mongo = MongoDB()
 

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -13,7 +13,7 @@ def test_mongodb_backup(config_file, mocker, fake_process):
     archive = Path.home() / f"mongodb_blackbox_{date}.archive"
 
     command_to_run = [
-        f"mongodump --uri= --gzip --forceTableScan --archive={archive}"
+        f"mongodump --uri=mongodb://mongouser:mongopassword@host:port --gzip --forceTableScan --archive={archive}"
     ]
 
     fake_process.register_subprocess(

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -1,6 +1,6 @@
-import pytest
 import datetime
 from pathlib import Path
+
 
 def test_mongodb_backup(config_file, mocker, fake_process):
     """Test if the MongoDB database handler executes a backup"""
@@ -13,8 +13,8 @@ def test_mongodb_backup(config_file, mocker, fake_process):
     archive = Path.home() / f"mongodb_blackbox_{date}.archive"
 
     command_to_run = [
-            f"mongodump --uri= --gzip --forceTableScan --archive={archive}"
-        ]
+        f"mongodump --uri= --gzip --forceTableScan --archive={archive}"
+    ]
 
     fake_process.register_subprocess(
         command_to_run, stdout=["thing", "stuff"]

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -1,0 +1,25 @@
+import pytest
+import datetime
+from pathlib import Path
+
+def test_mongodb_backup(config_file, mocker, fake_process):
+    """Test if the MongoDB database handler executes a backup"""
+
+    from blackbox.handlers.databases import MongoDB
+
+    mongo = MongoDB()
+
+    date = datetime.datetime.today().strftime("%d_%m_%Y")
+    archive = Path.home() / f"mongodb_blackbox_{date}.archive"
+
+    command_to_run = [
+            f"mongodump --uri= --gzip --forceTableScan --archive={archive}"
+        ]
+
+    fake_process.register_subprocess(
+        command_to_run, stdout=["thing", "stuff"]
+    )
+
+    res = mongo.backup()
+
+    assert res == archive

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,6 @@ profile=google
 src_paths=blackbox
 force_single_line=True
 line_length=150
+
+[coverage:report]
+skip_empty = true


### PR DESCRIPTION
This bring mongodb to 100% coverage
```
Name                                      Stmts   Miss  Cover   
-------------------------------------------------------------
blackbox\handlers\databases\mongodb.py       14      0   100%
```

⚠️ _however_  for whatever reason the self.connstring isn't populated with the mocked connection string. That needs some looking in to I reckon.