### PR TITLE
Smarter config file loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,7 @@ dmypy.json
 .idea
 
 # Ignore the config file
-config.yaml
+blackbox.yaml
 
 # vscode
 .vscode/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Here's an example manifest you can use if you want to run this in a Kubernetes c
 ```
 
 # Configuration
-`blackbox` can be configured in a number of ways. To set it up, create a `config.yaml` file in the root folder. Here's an example of what it should contain:
+`blackbox` configuration is easy. You simply create a yaml file, `blackbox.yaml`, which contains something like this:
+
 ```yaml
 databases:
   - mongodb://username:password@host:port
@@ -38,9 +39,14 @@ notifiers:
 retention_days: 7
 ```
 
+Blackbox will look for this file in the root folder by default, however you can provide an alternative config file path by creating an environment variable called `BLACKBOX_CONFIG_PATH`, and set it to the absolute path of the file.
+```sh
+export BLACKBOX_CONFIG_PATH=/var/my/favorite/fruit/blackbox.yaml
+```
+
 ## Environment Variables
 
-The `config.yaml` will ✨ **magically interpolate** ✨ any environment variables that exist in the environment where `blackbox` is running. This is very useful if you want to keep your secrets in environment variables, instead of keeping them in the config file in plaintext.
+The `blackbox.yaml` will ✨ **magically interpolate** ✨ any environment variables that exist in the environment where `blackbox` is running. This is very useful if you want to keep your secrets in environment variables, instead of keeping them in the config file in plaintext.
 
 #### Example
 Imagine your current config looks like this, but you want to move the username and password into environment variables.
@@ -136,4 +142,4 @@ These usually look something like `https://discord.com/api/webhooks/797541821394
 ##  Rotation
 By default, `blackbox` will automatically remove all backup files older than 7 days in the folder you configure for your storage provider. To determine if something is a backup file or not, it will use a regex pattern that corresponds with the default file it saves, for example `blackbox-postgres-backup-11-12-2020.sql`.
 
-You can configure the number of days before rotating by altering the `retention_days` parameter in `config.yaml`.
+You can configure the number of days before rotating by altering the `retention_days` parameter in `blackbox.yaml`.

--- a/blackbox/config.py
+++ b/blackbox/config.py
@@ -1,7 +1,8 @@
+import os
+from pathlib import Path
+
 from blackbox.utils.logger import log
 from blackbox.utils.yaml import get_yaml_config
-
-_CONFIG_YAML = get_yaml_config()
 
 
 class YAMLGetter(type):
@@ -37,6 +38,24 @@ class YAMLGetter(type):
     """
     section = None
     subsection = None
+    _config = None
+
+    @classmethod
+    def parse_config(cls, config_path: Path = None):
+        """Parse the config from the blackbox.yaml file."""
+        # If config_path is passed, use that.
+        if config_path:
+            cls._config = get_yaml_config(config_path)
+
+        # Otherwise, if there's an environment variable with a path, we'll use that.
+        env_config_path = os.environ.get("BLACKBOX_CONFIG_PATH")
+        if env_config_path:
+            cls._config = get_yaml_config(Path(env_config_path))
+
+        # Otherwise, we expect the config file to be in the root folder,
+        # and to be called 'blackbox.yaml'
+        root_folder = Path(__file__).parent.parent.absolute()
+        cls._config = get_yaml_config(root_folder / "blackbox.yaml")
 
     def _get_annotation(cls, name):
         """Fetch the annotation configured in the subclass."""
@@ -44,20 +63,30 @@ class YAMLGetter(type):
 
     def __getattr__(cls, name):
         """
-        Fetch the attribute in the _CONFIG_YAML dictionary.
+        Fetch the attribute in the `YAMLGetter.config` dictionary.
 
-        This just attempts to do a dictionary lookup in the _CONFIG_YAML we unpacked earlier,
+        This just attempts to do a dictionary lookup in `YAMLGetter.config`,
         and supports sections and subsections if we need nested blackbox data.
         """
         name = name.lower()
 
+        # Here's a bit of magic - We don't set the cls._config until the first time
+        # something tries to actually call this method. This kind of just-in-time approach
+        # allows us to comfortably modify the `_config` at some point before we start using
+        # any of the Handlers, without worrying about any race conditions.
+        #
+        # If you need this config to be set before or after the first call to __getattr__, simply call
+        # YAMLGetter.parse_config(). You can pass in a configuration file path if you need to.
+        if not cls._config:
+            cls.parse_config()
+
         try:
             if cls.section is None:
-                return _CONFIG_YAML[name]
+                return cls._config[name]
             elif cls.subsection is None:
-                return _CONFIG_YAML[cls.section][name]
+                return cls._config[cls.section][name]
             else:
-                return _CONFIG_YAML[cls.section][cls.subsection][name]
+                return cls._config[cls.section][cls.subsection][name]
         except KeyError:
             # If one of the handler lists isn't defined, return an empty list.
             log.warning(f"{name} is not defined in the config.yaml file -- returning an falsy value.")

--- a/blackbox/config.py
+++ b/blackbox/config.py
@@ -89,7 +89,7 @@ class YAMLGetter(type):
                 return cls._config[cls.section][cls.subsection][name]
         except KeyError:
             # If one of the handler lists isn't defined, return an empty list.
-            log.warning(f"{name} is not defined in the config.yaml file -- returning an falsy value.")
+            log.warning(f"{name} is not defined in the blackbox.yaml file -- returning an falsy value.")
             if cls._get_annotation(name) == list:
                 return []
             elif cls._get_annotation(name) == dict:

--- a/blackbox/utils/yaml.py
+++ b/blackbox/utils/yaml.py
@@ -10,13 +10,12 @@ import yaml
 from blackbox.exceptions import ImproperlyConfigured
 
 
-def get_yaml_config() -> dict:
+def get_yaml_config(config_path: pathlib.Path) -> dict:
     """Load the yaml file in the root folder, and return it as a dict."""
     template = Environment(undefined=StrictUndefined)
-    root_folder = pathlib.Path(__file__).parent.parent.parent.absolute()
 
     try:
-        with open(root_folder / "config.yaml", encoding="UTF-8", mode="r") as f:
+        with open(config_path, encoding="UTF-8", mode="r") as f:
             # Inject the local environment variables into the rendering context.
             # This bit of magic allows us to resolve any {{ VARIABLE }} to whatever
             # the value of the equivalent environment variable is.
@@ -35,6 +34,6 @@ def get_yaml_config() -> dict:
 
     except FileNotFoundError as e:
         raise ImproperlyConfigured(
-            "You must create a config.yaml file in the root folder! "
+            f"Your blackbox.yaml file was not found at {config_path}!"
             "See the readme under 'Configuration' for more information."
         ) from e

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     volumes:
-      - ./config.yaml:/blackbox/config.yaml
+      - ./blackbox.yaml:/blackbox/blackbox.yaml
       - ./main.py:/blackbox/main.py
       - ./blackbox:/blackbox/blackbox
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,19 +1,14 @@
 import pytest
 
+from blackbox.config import Blackbox
+from blackbox.config import YAMLGetter
 from blackbox.exceptions import ImproperlyConfigured
-
-# There are imports inside the test functions because
-# the blackbox package needs to be imported after patching open()
-# as the get_yaml_config() is called implicitly at package import
 
 
 def test_config_gets_correct_values(config_file):
     """Test if the YAMLGetter class gets the values we expect it to get."""
-
-    from blackbox.config import Blackbox
-    from blackbox.utils.yaml import get_yaml_config
-
-    _config = get_yaml_config()
+    YAMLGetter.parse_config()
+    _config = YAMLGetter._config
 
     for name, value in Blackbox:
         if name in _config:
@@ -22,17 +17,11 @@ def test_config_gets_correct_values(config_file):
 
 def test_config_render_fails(config_file_with_errors):
     """Test if the YAMLGetter class gets the values we expect it to get."""
-
-    from blackbox.utils.yaml import get_yaml_config
-
     with pytest.raises(ImproperlyConfigured):
-        get_yaml_config()
+        YAMLGetter.parse_config()
 
 
 def test_config_missing_value(config_file_with_missing_value):
     """Test if the YAMLGetter class gets the values we expect it to get."""
-
-    from blackbox.utils.yaml import get_yaml_config
-
     with pytest.raises(ImproperlyConfigured):
-        get_yaml_config()
+        YAMLGetter.parse_config()


### PR DESCRIPTION
- Don't load the config on package import.
- Make `get_yaml_config` take a Path to load from.
- Update config-related tests.
