### PR TITLE
WIP CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def config_file(mocker):
 
         retention_days: 7
         """
-    )
+    ).lstrip()
 
     environment_variables = {
         "MONGO_USER": "mongouser",
@@ -39,6 +39,8 @@ def config_file(mocker):
     mocker.patch.dict(os.environ, environment_variables)
 
     mocker.patch("builtins.open", mocker.mock_open(read_data=config))
+
+    return config
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from os import remove as delete_file
+from tempfile import NamedTemporaryFile
+
+from click.testing import CliRunner
+
+from blackbox.__main__ import cli
+from blackbox.__version__ import __version__
+
+
+def test_cli_outputs_version_number():
+    """
+    Test CLI --version flag
+    """
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--version'])
+    assert result.exit_code == 0
+    assert result.output == f'{__version__}\n'
+
+
+def test_cli_run(config_file, mocker):
+    """
+    Test CLI --version flag
+    """
+    # TODO: Find a way to mock the database.backup() and other calls that are wrapped in abstraction
+    temp = NamedTemporaryFile("w", delete=False)
+    temp.write(config_file)
+    temp.close()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--config', temp.name])
+
+    # Cleanup
+    delete_file(temp.name)
+
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds a test that runs through a full CLI call from start to finish mocking away all tests formulated in unit tests.

Note this is a draft PR for now until I've found a good way to patch abstract class functions