### PR TITLE
Chunk compression into disk to reduce memory usage.

### DIFF
--- a/blackbox/handlers/storage/_base.py
+++ b/blackbox/handlers/storage/_base.py
@@ -1,24 +1,35 @@
 import gzip
-import io
+import shutil
+import tempfile
+import typing
 from abc import abstractmethod
 from pathlib import Path
 
 from blackbox.handlers._base import BlackboxHandler
+from blackbox.utils.logger import log
 
 
 class BlackboxStorage(BlackboxHandler):
     """An abstract interface for creating Blackbox Storage Providers."""
 
     @staticmethod
-    def compress(file_path: Path) -> io.BytesIO:
+    def compress(file_path: Path) -> typing.IO:
         """
-        Compress the file to gzip.
+        Compresses the file using gzip into a tempfile.TemporaryFile.
 
+        Returns a file-like object, which is removed when it is closed.
         This should always be called before syncing the
         file to a storage provider.
         """
-        gzipped_bytes = gzip.compress(file_path.read_bytes())
-        return io.BytesIO(gzipped_bytes)
+        temp_file = tempfile.NamedTemporaryFile(suffix=f"-{file_path.name}")
+
+        log.debug(f"Compressing to temporary file: {temp_file.name}")
+        with file_path.open(mode="rb") as f_in:
+            with gzip.open(temp_file, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        temp_file.seek(0)
+        return temp_file
 
     @abstractmethod
     def sync(self, file_path: Path):

--- a/blackbox/handlers/storage/_base.py
+++ b/blackbox/handlers/storage/_base.py
@@ -15,7 +15,7 @@ class BlackboxStorage(BlackboxHandler):
     @staticmethod
     def compress(file_path: Path) -> typing.IO:
         """
-        Compresses the file using gzip into a tempfile.TemporaryFile.
+        Compress the file using gzip into a tempfile.TemporaryFile.
 
         Returns a file-like object, which is removed when it is closed.
         This should always be called before syncing the

--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -42,11 +43,13 @@ class Dropbox(BlackboxStorage):
         # in multiple parts.
         chunk_size = 4 * 1024 * 1024
 
-        upload_path = f"{self.upload_base}{file_path.name}"
+        temp_file = self.compress(file_path)
+        upload_path = f"{self.upload_base}{file_path.name}.gz"
 
         try:
-            with file_path.open("rb") as f:
-                file_size = file_path.stat().st_size
+            with temp_file as f:
+                file_size = os.stat(f.name).st_size
+                log.debug(file_size)
                 if file_size <= chunk_size:
                     self.client.files_upload(
                         f.read(), upload_path, WriteMode.overwrite

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -84,7 +84,8 @@ class S3(BlackboxStorage):
             self.client.upload_fileobj(
                 file_,
                 self.bucket,
-                file_path.name,
+                f"{file_path.name}.gz",
+                ExtraArgs={"ContentEncoding": "gzip"}
             )
             self.success = True
         except (ClientError, BotoCoreError) as e:


### PR DESCRIPTION
The current implementation of `compress` reads the whole file into memory using `read_bytes`, then gzip compresses it into memory, which takes up a lot of RAM usage.

I tested this using a 3 GB Postgres database backup, which revealed a spike in memory usage during compression to the same size of the backup. The transfer method for s3, `upload_fileobj`, did not contribute to any noticeable spike in memory usage, and from the documentation, the upload [is already split to 8MB chunks](https://boto3.amazonaws.com/v1/documentation/api/latest/_modules/boto3/s3/transfer.html#TransferConfig).

The fix is to read the backup file in chunks using `shutil.copyfileobj`, and to compress using gzip on the fly straight to a `TemporaryFile` on the disk. The temporary file-object is then removed automatically after the upload to storage, so we do not keep redundant copies of the backup around.

Caveats:
- Currently the compression is done in the `sync` method of each storage, so the same backup will be compressed twice if both storage handlers (s3 and dropbox) are used. The solution might be to use `tempfile.mkstemp` in `cli` and pass the handler to each sync method, but it is prone to error and not urgent as of right now.

Maybe addresses #49.