### PR TITLE
Use .gitattributes to normalise line endings on check-in

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Relying on git to handle line endings means contributors have more
flexibility with which line endings they want to use on check-out.
The settings in .gitattributes only impose which line endings will
be used upon check-in (LF), which should not impact local development;
git will still respect the core.eol and core.autocrlf settings.