### PR TITLE
MariaDB and MySQL support

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -18,15 +18,6 @@ jobs:
           tag=$(cut -c 1-7 <<< $GITHUB_SHA)
           echo "::set-output name=tag::$tag"
 
-      # Create a version.month.day tag for the container repositories
-      - name: Create Container Tag
-        id: date
-        run: |
-          MONTH=`date +'%m'`
-          DAY=`date +'%d'`
-          tag=1.$MONTH.$DAY
-          echo "::set-output name=tag::$tag"
-
       # Check out the current repository
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -42,8 +33,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
 
       # Build and push the container to the GitHub Container
-      # Repository. The container will be tagged as "latest",
-      # "1.MONTH.DAY" (example "1.04.03")
+      # Repository. The container will be tagged as "latest"
       # and with the short SHA of the commit.
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -56,4 +46,3 @@ jobs:
           tags: |
             lemonsaurus/blackbox:latest
             lemonsaurus/blackbox:${{ steps.sha_tag.outputs.tag }}
-            lemonsaurus/blackbox:${{ steps.date.outputs.tag }}

--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -18,6 +18,16 @@ jobs:
           tag=$(cut -c 1-7 <<< $GITHUB_SHA)
           echo "::set-output name=tag::$tag"
 
+      # Create a version.month.day tag for the container repositories
+      - name: Create Container Tag
+        id: date
+        run: |
+          export MONTH=`date +'%m'`
+          export DAY=`date +'%d'`
+          TAG=1.$MONTH.$DAY
+          echo $TAG
+          export TAG
+
       # Check out the current repository
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -22,11 +22,10 @@ jobs:
       - name: Create Container Tag
         id: date
         run: |
-          export MONTH=`date +'%m'`
-          export DAY=`date +'%d'`
-          TAG=1.$MONTH.$DAY
-          echo $TAG
-          export TAG
+          MONTH=`date +'%m'`
+          DAY=`date +'%d'`
+          tag=1.$MONTH.$DAY
+          echo "::set-output name=tag::$tag"
 
       # Check out the current repository
       - name: Checkout repository
@@ -43,7 +42,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
 
       # Build and push the container to the GitHub Container
-      # Repository. The container will be tagged as "latest"
+      # Repository. The container will be tagged as "latest",
+      # "1.MONTH.DAY" (example "1.04.03")
       # and with the short SHA of the commit.
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -56,3 +56,4 @@ jobs:
           tags: |
             lemonsaurus/blackbox:latest
             lemonsaurus/blackbox:${{ steps.sha_tag.outputs.tag }}
+            lemonsaurus/blackbox:${{ steps.date.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![PyPI version](https://badge.fury.io/py/blackbox-cli.svg)](https://pypi.org/project/blackbox-cli/)
 
 ![blackbox](https://github.com/lemonsaurus/blackbox/raw/main/img/blackbox_banner.png)
-A simple service which magically backs up all your databases to all your favorite cloud storage providers, and then notifies you.
+A simple service which magically backs up all your databases to all your
+favorite cloud storage providers, and then notifies you.
 
-Simply create a config file, fill in some connection strings for your favorite services, and schedule `blackbox` to run however often you want using something like `cron`, or a Kubernetes CronJob.
+Simply create a config file, fill in some connection strings for your favorite
+services, and schedule `blackbox` to run however often you want using something
+like `cron`, or a Kubernetes CronJob.
 
 ## Table of Contents
 
@@ -15,6 +18,8 @@ Simply create a config file, fill in some connection strings for your favorite s
 - [Databases](#databases)
     - [MongoDB](#mongodb)
     - [PostgreSQL](#postgres)
+    - [MariaDB](#mariadb)
+    - [MySQL](#mysql)
     - [Redis](#redis)
     - [Specify Storage Providers and Notifiers for each Database](#specify-storage-providers-and-notifiers-for-each-database)
 - [Storage Providers](#storage-providers)
@@ -26,9 +31,12 @@ Simply create a config file, fill in some connection strings for your favorite s
 - [Rotation](#rotation)
 
 # Setup
-This service can either be set up as a cron job (on UNIX systems), as a Kubernetes CronJob, or scheduled in your favorite alternative scheduler.
+
+This service can either be set up as a cron job (on UNIX systems), as a
+Kubernetes CronJob, or scheduled in your favorite alternative scheduler.
 
 ## Quick start
+
 Requires Python 3.9 or newer
 
 ```sh
@@ -44,7 +52,9 @@ blackbox --config=/path/to/blackbox.yaml
 
 ### Setting up as a cron job
 
-All you need to do to set it up as a cron job is clone this repo, create a config file (see below), and trigger `blackbox` to run automatically however often you want.
+All you need to do to set it up as a cron job is clone this repo, create a
+config file (see below), and trigger `blackbox` to run automatically however
+often you want.
 
 ```sh
 crontab -e
@@ -55,11 +65,18 @@ crontab -e
 
 ### Setting it up as a Kubernetes CronJob
 
-To set this up as a Kubernetes CronJob, you'll want three manifests and a secret.
+To set this up as a Kubernetes CronJob, you'll want three manifests and a
+secret.
 
-Before we start, you'll probably want to create a Secret where you expose environment variables containing stuff like passwords for your databases, credentials for your storage, and webhooks as environment variables. We'll be interpolating those into the config file.
+Before we start, you'll probably want to create a Secret where you expose
+environment variables containing stuff like passwords for your databases,
+credentials for your storage, and webhooks as environment variables. We'll be
+interpolating those into the config file.
 
-Next, we'll need a ConfigMap for the `blackbox.yaml` config file. See the Configuration section below for more information on what to put inside this file.
+Next, we'll need a ConfigMap for the `blackbox.yaml` config file. See the
+Configuration section below for more information on what to put inside this
+file.
+
 ```yaml
 # blackbox-configmap.yaml
 apiVersion: v1
@@ -89,7 +106,10 @@ data:
     retention_days: 7
 ```
 
-Next, we'll need to configure the `BLACKBOX_CONFIG_PATH`, which tells Blackbox where to find the config file. This doesn't need to be a secret, so we'll just put that into a regular ConfigMap.
+Next, we'll need to configure the `BLACKBOX_CONFIG_PATH`, which tells Blackbox
+where to find the config file. This doesn't need to be a secret, so we'll just
+put that into a regular ConfigMap.
+
 ```yaml
 # env-configmap.yaml
 apiVersion: v1
@@ -101,7 +121,9 @@ data:
   BLACKBOX_CONFIG_PATH: "/blackbox/config_file/blackbox.yaml"
 ```
 
-Finally, we need the CronJob itself. This one is configured to run once a day, at midnight.
+Finally, we need the CronJob itself. This one is configured to run once a day,
+at midnight.
+
 ```yaml
 # cronjob.yaml
 apiVersion: batch/v1beta1
@@ -115,20 +137,20 @@ spec:
       template:
         spec:
           containers:
-          - name: blackbox
-            image: lemonsaurus/blackbox
-            imagePullPolicy: Always
-            envFrom:
-              - secretRef:
-                  name: blackbox-secrets
-              - configMapRef:
-                  name: blackbox-env
-            volumeMounts:
-              # Take care not to mount this in the root folder!
-              # That will replace everything in the root folder with
-              # the contents of this volume, which sucks.
-              - mountPath: /blackbox/config_file
-                name: blackbox-config
+            - name: blackbox
+              image: lemonsaurus/blackbox
+              imagePullPolicy: Always
+              envFrom:
+                - secretRef:
+                    name: blackbox-secrets
+                - configMapRef:
+                    name: blackbox-env
+              volumeMounts:
+                # Take care not to mount this in the root folder!
+                # That will replace everything in the root folder with
+                # the contents of this volume, which sucks.
+                - mountPath: /blackbox/config_file
+                  name: blackbox-config
           volumes:
             - name: blackbox-config
               configMap:
@@ -138,14 +160,16 @@ spec:
 ```
 
 # Configuration
-`blackbox` configuration is easy. You simply create a yaml file, `blackbox.yaml`, which contains something like this:
+
+`blackbox` configuration is easy. You simply create a yaml
+file, `blackbox.yaml`, which contains something like this:
 
 See below for specific configuration information for each handler.
 
 ```yaml
 databases:
-  postgres:  # Database type 
-    main_postgres:  # Database identifier
+  postgres: # Database type 
+    main_postgres: # Database identifier
       # Configuration (see below for further information on specific databases)
       username: username
       password: password
@@ -168,8 +192,8 @@ databases:
       # No specified storage and notifiers, so all storage and notifiers are used
 
 storage:
-  s3:  # Storage type
-    main_s3:  # Storage identifier
+  s3: # Storage type
+    main_s3: # Storage identifier
       bucket: bucket
       endpoint: s3.endpoint.com
     secondary_s3:
@@ -182,32 +206,42 @@ storage:
       access_token: XXXXXXXXXXX
 
 notifiers:
-  discord:  # Notifier type
-    main_discord:  # Notifier identifier
-      webhook:  https://discord.com/api/webhooks/797541821394714674/lzRM9DFggtfHZXGJTz3yE-MrYJ-4O-0AbdQg3uV2x4vFbu7HTHY2Njq8cx8oyMg0T3Wk
+  discord: # Notifier type
+    main_discord: # Notifier identifier
+      webhook: https://discord.com/api/webhooks/797541821394714674/lzRM9DFggtfHZXGJTz3yE-MrYJ-4O-0AbdQg3uV2x4vFbu7HTHY2Njq8cx8oyMg0T3Wk
   slack:
     main_slack:
-      webhook:  https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXXX/XXXXXXXXXXXXXXXXXXX
+      webhook: https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXXX/XXXXXXXXXXXXXXXXXXX
 
 retention_days: 7
 ```
 
-Blackbox will look for this file in the root folder by default, however you can provide an alternative config file path by creating an environment variable called `BLACKBOX_CONFIG_PATH`, and set it to the absolute path of the file.
+Blackbox will look for this file in the root folder by default, however you can
+provide an alternative config file path by creating an environment variable
+called `BLACKBOX_CONFIG_PATH`, and set it to the absolute path of the file.
 
 ```sh
 export BLACKBOX_CONFIG_PATH=/var/my/favorite/fruit/blackbox.yaml
 ```
 
-You can also specify the location of this file when using the `blackbox` cli command.
+You can also specify the location of this file when using the `blackbox` cli
+command.
+
 ```sh
 blackbox --config=/path/to/blackbox.yaml
 ```
 
 ## Environment Variables
-The `blackbox.yaml` will ✨ **magically interpolate** ✨ any environment variables that exist in the environment where `blackbox` is running. This is very useful if you want to keep your secrets in environment variables, instead of keeping them in the config file in plaintext.
+
+The `blackbox.yaml` will ✨ **magically interpolate** ✨ any environment
+variables that exist in the environment where `blackbox` is running. This is
+very useful if you want to keep your secrets in environment variables, instead
+of keeping them in the config file in plaintext.
 
 #### Example
-Imagine your current config looks like this, but you want to move the username and password into environment variables.
+
+Imagine your current config looks like this, but you want to move the username
+and password into environment variables.
 
 ```yaml
 databases:
@@ -226,22 +260,27 @@ export POSTGRES_USERNAME=lemonsaurus
 export POSTGRES_PASSWORD=security-is-overrated
 ```
 
-And now we can make use of these environment variables by using double curly brackets, like this:
+And now we can make use of these environment variables by using double curly
+brackets, like this:
 
 ```yaml
 databases:
   postgres:
     main_postgres:
-      username: {{ POSTGRES_USERNAME }}
-      password: {{ POSTGRES_PASSWORD }}
+      username: { { POSTGRES_USERNAME } }
+      password: { { POSTGRES_PASSWORD } }
       host: localhost
       port: 5432
 ```
 
 ## Databases
-Right now, this app supports **MongoDB**, **PostgreSQL 12** and **Redis**. If you need support for an additional database, consider opening a pull request to add a new database handler.
+
+Right now, this app supports **MongoDB**, **PostgreSQL 12** and **Redis**. If
+you need support for an additional database, consider opening a pull request to
+add a new database handler.
 
 To configure databases, add a section with this format:
+
 ```yaml
 databases:
   database_type:
@@ -254,13 +293,23 @@ databases:
     ...
 ```
 
-See below for the specific database types available and fields required. Identifiers can be any string of your choosing.
+See below for the specific database types available and fields required.
+Identifiers can be any string of your choosing.
 
 ### MongoDB
+
 - **Database Type**: `mongodb`
 - **Required fields**: `connection_string`
-- The `connection_string` field is in the format `mongodb://username:password@host:port`
-- To restore from the backup, use `mongorestore --gzip --archive=/path/to/backup.archive`
+- The `connection_string` field is in the
+  format `mongodb://username:password@host:port`
+- To restore from the backup,
+  use `mongorestore --gzip --archive=/path/to/backup.archive`
+
+```yaml
+  mongodb:
+    main_mongo:
+      connection_string: "mongodb://blackbox:blackbox@mongo:27017"
+```
 
 ### Postgres
 
@@ -268,14 +317,64 @@ See below for the specific database types available and fields required. Identif
 - **Required fields**: `username`, `password`, `host`, `port`
 - To restore from the backup, use `psql -f /path/to/backup.sql`
 
+```yaml
+  postgres:
+    main_postgres:
+      username: blackbox
+      password: blackbox
+      host: postgres
+      port: "5432"
+```
+
+### MariaDB
+
+- **Database Type**: `mariadb`
+- **Required fields**: `username`, `password`, `host`, `port`
+- To restore from the backup, use `mysql -u <user> -p < db_backup.sql`
+
+```yaml
+  mariadb:
+    main_mariadb:
+      username: root
+      password: example
+      host: maria
+      port: "3306"
+```
+
+### MySQL
+
+- **Database Type**: `mysql`
+- **Required fields**: `username`, `password`, `host`, `port`
+- To restore from the backup, use `mysql -u <user> -p < db_backup.sql`
+
+```yaml
+  mysql:
+    main_mysql:
+      username: root
+      password: example
+      host: mysql
+      port: "3306"
+```
+
 ### Redis
+
 - **Database Type**: `redis`
 - **Required fields**: `password`, `host`, `port`
 
+```yaml
+  redis:
+    main_redis:
+      password: blackbox
+      host: redis
+      port: "6379"
+```
+
 #### To restore from the backup
+
 - Stop Redis server.
 - Turn off `appendonly` mode in Redis configuration (set to `no`).
-- Copy backup file to Redis working directory (`dir` in configuration) with name that is defined in configuration key `dbfilename`.
+- Copy backup file to Redis working directory (`dir` in configuration) with
+  name that is defined in configuration key `dbfilename`.
 - Set backup permissions.
 
 ```
@@ -296,11 +395,14 @@ If you want to re-enable `appendonly`:
 
 ### Specify Storage providers and Notifiers for each Database
 
-To specify specific storage providers or notifiers for databases, add the fields `storage_providers` and `notifiers` under each database entry. The entry can be a list or a string.
+To specify specific storage providers or notifiers for databases, add the
+fields `storage_providers` and `notifiers` under each database entry. The entry
+can be a list or a string.
+
 ```yaml
 databases:
-  postgres:  # Database type 
-    main_postgres:  # Database identifier
+  postgres: # Database type 
+    main_postgres: # Database identifier
       username: username
       password: password
       host: host
@@ -312,14 +414,21 @@ databases:
       notifiers: slack
 ```
 
-The above example will backup `main_postgres` to every `s3` storage provider configured, as well as the storage provider with the identifier `secondary_dropbox`. Then, only the `slack` notifier gets notified.
+The above example will backup `main_postgres` to every `s3` storage provider
+configured, as well as the storage provider with the
+identifier `secondary_dropbox`. Then, only the `slack` notifier gets notified.
 
-These fields are optional. If not given, all storage providers and all notifiers will be used.
+These fields are optional. If not given, all storage providers and all
+notifiers will be used.
 
 ## Storage providers
-**Blackbox** can work with different storage providers to save your logs and backups - usually so that you can automatically store them in the cloud. Right now we support **S3** and **Dropbox**.
+
+**Blackbox** can work with different storage providers to save your logs and
+backups - usually so that you can automatically store them in the cloud. Right
+now we support **S3** and **Dropbox**.
 
 To configure storage providers, add a section with this format:
+
 ```yaml
 storage:
   storage_type:
@@ -333,45 +442,67 @@ storage:
 ```
 
 ### S3
-We support any S3 object storage bucket, whether it's from **AWS**, **Linode**, **DigitalOcean**, **Scaleway**, or another S3-compatible object storage provider.
 
-**Blackbox** will respect the `retention_days` configuration setting and delete older files from the S3 storage. Please note that if you have a bucket expiration policy on your storage, **blackbox** will not do anything to disable it. So, for example, if your bucket expiration policy is 12 hours and blackbox is set to 7 `retention_days`, then your backups are all gonna be deleted after 12 hours unless you disable your policy.
+We support any S3 object storage bucket, whether it's from **AWS**, **Linode**
+, **DigitalOcean**, **Scaleway**, or another S3-compatible object storage
+provider.
 
-#### Configuration
+**Blackbox** will respect the `retention_days` configuration setting and delete
+older files from the S3 storage. Please note that if you have a bucket
+expiration policy on your storage, **blackbox** will not do anything to disable
+it. So, for example, if your bucket expiration policy is 12 hours and blackbox
+is set to 7 `retention_days`, then your backups are all gonna be deleted after
+12 hours unless you disable your policy.
+
+#### S3 configuration
+
 - **Storage Type**: `s3`
 - **Required fields**: `bucket`, `endpoint`
 - **Optional fields**: `aws_access_key_id`, `aws_secret_access_key`
-- The `endpoint` field can look something like this: `s3.eu-west-1.amazonaws.com`
+- The `endpoint` field can look something like
+  this: `s3.eu-west-1.amazonaws.com`
 
 #### Credentials
-To upload stuff to S3, you'll need credentials. Your **AWS credentials** can be provided in several ways. This is the order in which blackbox looks for them:
 
-- First, we look for the optional fields in the s3 configuration, called `aws_access_key_id` and `aws_secret_access_key`.
-- If these are not found, we'll check if the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables are declared in the local environment where Blackbox is running.
-- If we can't find these, we'll look for an `.aws/config` file in the local environment.
+To upload stuff to S3, you'll need credentials. Your **AWS credentials** can be
+provided in several ways. This is the order in which blackbox looks for them:
+
+- First, we look for the optional fields in the s3 configuration,
+  called `aws_access_key_id` and `aws_secret_access_key`.
+- If these are not found, we'll check if the `AWS_ACCESS_KEY_ID`
+  and `AWS_SECRET_ACCESS_KEY` environment variables are declared in the local
+  environment where Blackbox is running.
+- If we can't find these, we'll look for an `.aws/config` file in the local
+  environment.
 - NOTE: If the bucket is public, no credentials are necessary.
 
 ### Dropbox
-The Dropbox storage handler needs a user access token in order to work. To get one, do the following:
-
-- Create a Dropbox account (if you don't already have one).
-- Go to https://dropbox.com/developers
-- Create a new application with App Folder access. **Do not give it full access**, as this may have dangerous, destructive consequences if configured incorrectly.
-
-You can also define a custom location (root is App Folder) using the
-`upload_directory` optional parameter. This **should** begin with slash
-and **must** end with slash. Default is root.
-
-#### Configuration
 
 - **Storage Type**: `dropbox`
 - **Required fields**: `access_token`
 - **Optional fields**: `upload_directory`
 
+The Dropbox storage handler needs a user access token in order to work. To get
+one, do the following:
+
+- Create a Dropbox account (if you don't already have one).
+- Go to https://dropbox.com/developers
+- Create a new application with App Folder access. **Do not give it full
+  access**, as this may have dangerous, destructive consequences if configured
+  incorrectly.
+
+You can also define a custom location (root is App Folder) using the
+`upload_directory` optional parameter. This **should** begin with slash and **
+must** end with slash. Default is root.
+
 ## Notifiers
-`blackbox` also implements different _notifiers_, which is how it reports the result of one of its jobs to you. Right now we only support **Discord** and **Slack**, but if you need a specific notifier, feel free to open an issue.
+
+`blackbox` also implements different _notifiers_, which is how it reports the
+result of one of its jobs to you. Right now we only support **Discord** and **
+Slack**, but if you need a specific notifier, feel free to open an issue.
 
 To configure notifiers, add a section with this format:
+
 ```yaml
 notifiers:
   notifier_type:
@@ -388,7 +519,8 @@ notifiers:
 
 - **Notifier Type**: `discord`
 - **Required fields**: `webhook`
-- The `webhook` field usually looks like `https://discord.com/api/webhooks/797541821394714674/lzRM9DFggtfHZXGJTz3yE-MrYJ-4O-0AbdQg3uV2x4vFbu7HTHY2Njq8cx8oyMg0T3Wk`
+- The `webhook` field usually looks
+  like `https://discord.com/api/webhooks/797541821394714674/lzRM9DFggtfHZXGJTz3yE-MrYJ-4O-0AbdQg3uV2x4vFbu7HTHY2Njq8cx8oyMg0T3Wk`
 - We also support `ptb.discord.com` and `canary.discord.com` webhooks.
 
 ![blackbox](https://github.com/lemonsaurus/blackbox/raw/main/img/blackbox_discord.png)
@@ -398,11 +530,12 @@ notifiers:
 
 - **Notifier Type**: `slack`
 - **Required fields**: `webhook`
-- The `webhook` field usually looks like `https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXXX/XXXXXXXXXXXXXXXXXXX`
+- The `webhook` field usually looks
+  like `https://hooks.slack.com/services/XXXXXXXXXXX/XXXXXXXXXXX/XXXXXXXXXXXXXXXXXXX`
 
-
-Slack notifiers have 2 styles: legacy attachment (default) and modern Block Kit version.
-To enable Block Kit version, set the optional field `use_block_kit` to anything.
+Slack notifiers have 2 styles: legacy attachment (default) and modern Block Kit
+version. To enable Block Kit version, set the optional field `use_block_kit` to
+anything.
 
 Default:
 
@@ -415,6 +548,12 @@ Modern:
 ![blackbox](https://github.com/lemonsaurus/blackbox/raw/main/img/blackbox_slack_modern_fail.png)
 
 ## Rotation
-By default, `blackbox` will automatically remove all backup files older than 7 days in the folder you configure for your storage provider. To determine if something is a backup file or not, it will use a regex pattern that corresponds with the default file it saves, for example `blackbox-postgres-backup-11-12-2020.sql`.
 
-You can configure the number of days before rotating by altering the `retention_days` parameter in `blackbox.yaml`.
+By default, `blackbox` will automatically remove all backup files older than 7
+days in the folder you configure for your storage provider. To determine if
+something is a backup file or not, it will use a regex pattern that corresponds
+with the default file it saves, for
+example `blackbox-postgres-backup-11-12-2020.sql`.
+
+You can configure the number of days before rotating by altering
+the `retention_days` parameter in `blackbox.yaml`.

--- a/blackbox/handlers/__init__.py
+++ b/blackbox/handlers/__init__.py
@@ -1,3 +1,3 @@
 from .databases import BlackboxDatabase
-from .storage import BlackboxStorage
 from .notifiers import BlackboxNotifier
+from .storage import BlackboxStorage

--- a/blackbox/handlers/databases/__init__.py
+++ b/blackbox/handlers/databases/__init__.py
@@ -1,4 +1,6 @@
 from ._base import BlackboxDatabase
+from .mariadb import MariaDB
 from .mongodb import MongoDB
+from .mysql import MySQL
 from .postgres import Postgres
 from .redis import Redis

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -8,8 +8,7 @@ from blackbox.utils.logger import log
 
 class MariaDB(BlackboxDatabase):
     """
-    A Database handler that will do a
-    mysqldump for MariaDB, backing up all tables.
+    A Database handler that will do a mysqldump for MariaDB, backing up all tables.
     """
 
     required_fields = ("username", "password", "host", )
@@ -31,8 +30,8 @@ class MariaDB(BlackboxDatabase):
             f"--port={port} --all-databases > {backup_path}"
         )
         log.debug(self.output)
-        # Explicitly check if error message is occurred
-        # Somehow mysqldump is always successful
+        # Explicitly check if error message is occurred.
+        # Somehow mysqldump is always successful.
         if "error" in self.output.lower():
             self.success = False
             log.debug("mysqldump has error(s) in log")

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -31,6 +31,11 @@ class MariaDB(BlackboxDatabase):
             f"--port={port} --all-databases | gzip -7 > {backup_path}"
         )
         log.debug(self.output)
+        # Explicitly check if error message is occur
+        # Somehow mysqldump is always successful
+        if "error" in self.output:
+            self.success = False
+            log.debug("mysqldump has error(s) in log")
 
         # Return the path to the backup file
         return backup_path

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -7,9 +7,7 @@ from blackbox.utils.logger import log
 
 
 class MariaDB(BlackboxDatabase):
-    """
-    A Database handler that will do a mysqldump for MariaDB, backing up all tables.
-    """
+    """A Database handler that will do a mysqldump for MariaDB, backing up all tables."""
 
     required_fields = ("username", "password", "host", )
 

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -23,7 +23,7 @@ class MariaDB(BlackboxDatabase):
         host = self.config["host"]
         port = self.config["port"]
 
-        backup_path = Path.home() / f"{host}_blackbox_{date}.sql"
+        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.sql"
 
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -28,12 +28,12 @@ class MariaDB(BlackboxDatabase):
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(
             f"mysqldump -h {host} -u {user} --password='{password}' "
-            f"--port={port} --all-databases | gzip -7 > {backup_path}"
+            f"--port={port} --all-databases > {backup_path}"
         )
         log.debug(self.output)
-        # Explicitly check if error message is occur
+        # Explicitly check if error message is occurred
         # Somehow mysqldump is always successful
-        if "error" in self.output:
+        if "error" in self.output.lower():
             self.success = False
             log.debug("mysqldump has error(s) in log")
 

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -1,0 +1,36 @@
+import datetime
+from pathlib import Path
+
+from blackbox.handlers.databases._base import BlackboxDatabase
+from blackbox.utils import run_command
+from blackbox.utils.logger import log
+
+
+class MariaDB(BlackboxDatabase):
+    """
+    A Database handler that will do a
+    mysqldump for MariaDB, backing up all tables.
+    """
+
+    required_fields = ("username", "password", "host", "port")
+
+    def backup(self) -> Path:
+        """Dump all the data to a file and then return the filepath."""
+        date = datetime.date.today().strftime("%d_%m_%Y")
+
+        user = self.config["username"]
+        password = self.config["password"]
+        host = self.config["host"]
+        port = self.config["port"]
+
+        backup_path = Path.home() / f"{host}_blackbox_{date}.sql"
+
+        # Run the backup, and store the outcome.
+        self.success, self.output = run_command(
+            f"mysqldump -h {host} -u {user} --password='{password}' "
+            f"--port={port} --all-databases | gzip -7 > {backup_path}"
+        )
+        log.debug(self.output)
+
+        # Return the path to the backup file
+        return backup_path

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -12,7 +12,7 @@ class MariaDB(BlackboxDatabase):
     mysqldump for MariaDB, backing up all tables.
     """
 
-    required_fields = ("username", "password", "host", "port")
+    required_fields = ("username", "password", "host", )
 
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
@@ -21,7 +21,7 @@ class MariaDB(BlackboxDatabase):
         user = self.config["username"]
         password = self.config["password"]
         host = self.config["host"]
-        port = self.config["port"]
+        port = str(self.config.get("port", "3306"))
 
         backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.sql"
 

--- a/blackbox/handlers/databases/mysql.py
+++ b/blackbox/handlers/databases/mysql.py
@@ -4,8 +4,7 @@ from blackbox.handlers.databases._base import BlackboxDatabase
 
 class MySQL(MariaDB, BlackboxDatabase):
     """
-    A Database handler that will do a
-    mysqldump for MySQL, backing up all tables.
+    A Database handler that will do a mysqldump for MySQL, backing up all tables.
     Identical to MariaDB.
     """
 

--- a/blackbox/handlers/databases/mysql.py
+++ b/blackbox/handlers/databases/mysql.py
@@ -1,0 +1,12 @@
+from blackbox.handlers.databases import MariaDB
+from blackbox.handlers.databases._base import BlackboxDatabase
+
+
+class MySQL(MariaDB, BlackboxDatabase):
+    """
+    A Database handler that will do a
+    mysqldump for MySQL, backing up all tables.
+    Identical to MariaDB.
+    """
+
+    pass

--- a/blackbox/handlers/databases/mysql.py
+++ b/blackbox/handlers/databases/mysql.py
@@ -3,9 +3,6 @@ from blackbox.handlers.databases._base import BlackboxDatabase
 
 
 class MySQL(MariaDB, BlackboxDatabase):
-    """
-    A Database handler that will do a mysqldump for MySQL, backing up all tables.
-    Identical to MariaDB.
-    """
+    """A Database handler that will do a mysqldump for MySQL, backing up all tables."""
 
     pass

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./docker/postgres/postgres_init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U blackbox"]
+      test: [ "CMD-SHELL", "pg_isready -U blackbox" ]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,11 @@ services:
       POSTGRES_PASSWORD: blackbox
     volumes:
       - ./docker/postgres/postgres_init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U blackbox"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   mongo:
     container_name: blackbox-mongo
@@ -18,12 +23,22 @@ services:
     volumes:
       - ./docker/mongo/init_data:/init_data
       - ./docker/mongo/mongo_import.sh:/docker-entrypoint-initdb.d/mongo_import.sh
+    healthcheck:
+      test: echo 'db.stats().ok' | mongo localhost:27017/blackbox --quiet
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   redis:
     container_name: blackbox-redis
     build:
       context: .
       dockerfile: docker/redis/Dockerfile
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 1s
+      timeout: 3s
+      retries: 30
 
   maria:
     container_name: blackbox-maria
@@ -31,6 +46,8 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "--silent" ]
 
   mysql:
     container_name: blackbox-mysql
@@ -39,6 +56,8 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "--silent" ]
 
   blackbox:
     container_name: blackbox
@@ -52,8 +71,13 @@ services:
     env_file:
       - docker/.env
     depends_on:
-      - postgres
-      - mongo
-      - redis
-      - maria
-      - mysql
+      postgres:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      maria:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,5 @@
 version: "3.7"
 services:
-  blackbox:
-    container_name: blackbox
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
-    volumes:
-      - ./blackbox.yaml:/blackbox/blackbox.yaml
-      - ./main.py:/blackbox/main.py
-      - ./blackbox:/blackbox/blackbox
-
   postgres:
     container_name: blackbox-postgres
     image: postgres:12
@@ -34,3 +24,36 @@ services:
     build:
       context: .
       dockerfile: docker/redis/Dockerfile
+
+  maria:
+    container_name: blackbox-maria
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+
+  mysql:
+    container_name: blackbox-mysql
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+
+  blackbox:
+    container_name: blackbox
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ./blackbox.yaml:/blackbox/blackbox.yaml
+      - ./main.py:/blackbox/main.py
+      - ./blackbox:/blackbox/blackbox
+    env_file:
+      - docker/.env
+    depends_on:
+      - postgres
+      - mongo
+      - redis
+      - maria
+      - mysql

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y mongo-tools redis-tools
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update -y && \
-    apt-get install -y postgresql-client-12
+    apt-get install -y postgresql-client-12 mariadb-client
 
 # Create and set the working directory, so we don't make a mess in the Docker filesystem.
 WORKDIR /blackbox


### PR DESCRIPTION
As MariaDB and MySQL have common roots we can use the same algorithm to backup them using `mysqldump`.
I've integrated it in Dockerfile of blackbox as part of MariaDB package
I added on docker-compose two new containers for that databases and introduced a `heathcheck` for every database so blackbox will start backup only when all databases ready.

Resolves #56
Resolves #16