### PR TITLE
Fix same filenames for multiple databases of one kind

### DIFF
--- a/blackbox/handlers/databases/mongodb.py
+++ b/blackbox/handlers/databases/mongodb.py
@@ -19,7 +19,7 @@ class MongoDB(BlackboxDatabase):
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
         date = datetime.date.today().strftime("%d_%m_%Y")
-        archive_file = Path.home() / f"mongodb_blackbox_{date}.archive"
+        archive_file = Path.home() / f"{self.config['id']}_blackbox_{date}.archive"
 
         # Run the backup, and store the outcome in this object.
         self.success, self.output = run_command(

--- a/blackbox/handlers/databases/postgres.py
+++ b/blackbox/handlers/databases/postgres.py
@@ -14,7 +14,7 @@ class Postgres(BlackboxDatabase):
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
         date = datetime.date.today().strftime("%d_%m_%Y")
-        backup_path = Path.home() / f"postgres_blackbox_{date}.sql"
+        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.sql"
 
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(

--- a/blackbox/handlers/databases/redis.py
+++ b/blackbox/handlers/databases/redis.py
@@ -14,7 +14,7 @@ class Redis(BlackboxDatabase):
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
         date = datetime.date.today().strftime("%d_%m_%Y")
-        backup_path = Path.home() / f"redis_blackbox_{date}.rdb"
+        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.rdb"
 
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -9,7 +9,8 @@ from blackbox.handlers.databases import MongoDB
 
 @pytest.fixture
 def mock_valid_mongodb_config():
-    return {"connection_string": "mongodb://mongouser:mongopassword@host:port"}
+    return {"connection_string": "mongodb://mongouser:mongopassword@host:port",
+            "id": "main_mongo", }
 
 
 @pytest.fixture
@@ -17,12 +18,14 @@ def mock_invalid_mongodb_config():
     return {}
 
 
-def test_mongodb_handler_can_be_instantiated_with_required_fields(mock_valid_mongodb_config):
+def test_mongodb_handler_can_be_instantiated_with_required_fields(
+        mock_valid_mongodb_config):
     """Test if the MongoDB database handler can be instantiated."""
     MongoDB(**mock_valid_mongodb_config)
 
 
-def test_mongodb_handler_fails_without_required_fields(mock_invalid_mongodb_config):
+def test_mongodb_handler_fails_without_required_fields(
+        mock_invalid_mongodb_config):
     """Test if the MongoDB database handler cannot be instantiated with missing fields."""
     with pytest.raises(MissingFields):
         MongoDB(**mock_invalid_mongodb_config)
@@ -34,7 +37,7 @@ def test_mongodb_backup(mock_valid_mongodb_config, fake_process):
     mongo = MongoDB(**mock_valid_mongodb_config)
 
     date = datetime.datetime.today().strftime("%d_%m_%Y")
-    archive = Path.home() / f"mongodb_blackbox_{date}.archive"
+    archive = Path.home() / f"main_mongo_blackbox_{date}.archive"
 
     command_to_run = [
         f"mongodump --uri=mongodb://mongouser:mongopassword@host:port --gzip --forceTableScan --archive={archive}"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -9,7 +9,8 @@ from blackbox.handlers.databases import Postgres
 
 @pytest.fixture
 def mock_valid_postgres_config():
-    return {"username": "lemon", "password": "citrus", "host": "localhost", "port": "5432"}
+    return {"username": "lemon", "password": "citrus", "host": "localhost",
+            "port": "5432", "id": "main_postgres", }
 
 
 @pytest.fixture
@@ -17,12 +18,14 @@ def mock_invalid_postgres_config():
     return {"username": "lime"}
 
 
-def test_postgres_handler_can_be_instantiated_with_required_fields(mock_valid_postgres_config):
+def test_postgres_handler_can_be_instantiated_with_required_fields(
+        mock_valid_postgres_config):
     """Test if the PostgreSQL database handler can be instantiated."""
     Postgres(**mock_valid_postgres_config)
 
 
-def test_postgres_handler_fails_without_required_fields(mock_invalid_postgres_config):
+def test_postgres_handler_fails_without_required_fields(
+        mock_invalid_postgres_config):
     """Test if the PostgreSQL database handler cannot be instantiated with missing fields."""
     with pytest.raises(MissingFields):
         Postgres(**mock_invalid_postgres_config)
@@ -33,7 +36,7 @@ def test_postgres_backup(mock_valid_postgres_config, fake_process):
 
     postgres = Postgres(**mock_valid_postgres_config)
     date = datetime.date.today().strftime("%d_%m_%Y")
-    backup_path = Path.home() / f"postgres_blackbox_{date}.sql"
+    backup_path = Path.home() / f"main_postgres_blackbox_{date}.sql"
 
     command_to_run = [
         f"pg_dumpall --file={backup_path}"

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -9,7 +9,8 @@ from blackbox.handlers.databases import Redis
 
 @pytest.fixture
 def mock_valid_redis_config():
-    return {"password": "citrus", "host": "localhost", "port": "5432"}
+    return {"password": "citrus", "host": "localhost", "port": "5432",
+            "id": "main_redis", }
 
 
 @pytest.fixture
@@ -17,12 +18,14 @@ def mock_invalid_redis_config():
     return {"password": "limoncello"}
 
 
-def test_redis_handler_can_be_instantiated_with_required_fields(mock_valid_redis_config):
+def test_redis_handler_can_be_instantiated_with_required_fields(
+        mock_valid_redis_config):
     """Test if the redis database handler can be instantiated."""
     Redis(**mock_valid_redis_config)
 
 
-def test_redis_handler_fails_without_required_fields(mock_invalid_redis_config):
+def test_redis_handler_fails_without_required_fields(
+        mock_invalid_redis_config):
     """Test if the redis database handler cannot be instantiated with missing fields."""
     with pytest.raises(MissingFields):
         Redis(**mock_invalid_redis_config)
@@ -34,7 +37,7 @@ def test_redis_backup(mock_valid_redis_config, fake_process):
     redis = Redis(**mock_valid_redis_config)
 
     date = datetime.date.today().strftime("%d_%m_%Y")
-    backup_path = Path.home() / f"redis_blackbox_{date}.rdb"
+    backup_path = Path.home() / f"main_redis_blackbox_{date}.rdb"
 
     command_to_run = [
         f"redis-cli -h {redis.config.get('host')} -p {redis.config.get('port')} --rdb {backup_path}"


### PR DESCRIPTION
This PR changes the filenames for backup files to include the ID, so that backups from different databases of the same kind don't overwrite each other.

Resolves  #71