### PR TITLE
Output is now masked. Notifiers has no sensitive information

### DIFF
--- a/blackbox/handlers/__init__.py
+++ b/blackbox/handlers/__init__.py
@@ -1,3 +1,3 @@
 from .databases import BlackboxDatabase
-from .storage import BlackboxStorage
 from .notifiers import BlackboxNotifier
+from .storage import BlackboxStorage

--- a/blackbox/handlers/__init__.py
+++ b/blackbox/handlers/__init__.py
@@ -1,3 +1,3 @@
 from .databases import BlackboxDatabase
-from .notifiers import BlackboxNotifier
 from .storage import BlackboxStorage
+from .notifiers import BlackboxNotifier

--- a/blackbox/handlers/_base.py
+++ b/blackbox/handlers/_base.py
@@ -1,9 +1,10 @@
 from abc import ABC
 
 from blackbox.exceptions import MissingFields
+from blackbox.utils.mixins import SanitizeReportMixin
 
 
-class BlackboxHandler(ABC):
+class BlackboxHandler(ABC, SanitizeReportMixin):
     """An abstract base handler."""
 
     required_fields = ()
@@ -31,11 +32,3 @@ class BlackboxHandler(ABC):
         teardown or cleanup after your handler has done whatever it is designed to do.
         """
         return None
-
-    def sanitize_output(self, sensitive_output: str) -> str:
-        """ Replace all self.config credentials with in any str *** """
-        for sensitive_word in self.config.values():
-            sensitive_output = sensitive_output.replace(
-                sensitive_word, "*" * len(sensitive_word))
-        sanitized_output = sensitive_output  # emphasize output is clear now
-        return sanitized_output

--- a/blackbox/handlers/_base.py
+++ b/blackbox/handlers/_base.py
@@ -17,12 +17,11 @@ class BlackboxHandler(ABC, SanitizeReportMixin):
     def _validate_config(self):
         """Ensure required configuration fields were passed to the handler."""
         handler_name = self.__class__.__name__
-        missing_fields = [field for field in self.required_fields if
-                          field not in self.config]
+        missing_fields = [field for field in self.required_fields if field not in self.config]
 
         if missing_fields:
-            raise MissingFields(self.handler_type, handler_name,
-                                self.config.get("id"), missing_fields)
+            raise MissingFields(self.handler_type, handler_name, self.config.get("id"),
+                                missing_fields)
 
     def teardown(self) -> None:
         """

--- a/blackbox/handlers/_base.py
+++ b/blackbox/handlers/_base.py
@@ -16,10 +16,12 @@ class BlackboxHandler(ABC):
     def _validate_config(self):
         """Ensure required configuration fields were passed to the handler."""
         handler_name = self.__class__.__name__
-        missing_fields = [field for field in self.required_fields if field not in self.config]
+        missing_fields = [field for field in self.required_fields if
+                          field not in self.config]
 
         if missing_fields:
-            raise MissingFields(self.handler_type, handler_name, self.config.get("id"), missing_fields)
+            raise MissingFields(self.handler_type, handler_name,
+                                self.config.get("id"), missing_fields)
 
     def teardown(self) -> None:
         """
@@ -29,3 +31,11 @@ class BlackboxHandler(ABC):
         teardown or cleanup after your handler has done whatever it is designed to do.
         """
         return None
+
+    def sanitize_output(self, sensitive_output: str) -> str:
+        """ Replace all self.config credentials with in any str *** """
+        for sensitive_word in self.config.values():
+            sensitive_output = sensitive_output.replace(
+                sensitive_word, "*" * len(sensitive_word))
+        sanitized_output = sensitive_output  # emphasize output is clear now
+        return sanitized_output

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -14,7 +14,7 @@ class BlackboxDatabase(BlackboxHandler):
         super().__init__(**kwargs)
 
         self.success = False  # Was the backup successful?
-        self.output = ""     # What did the backup output?
+        self.output = ""  # What did the backup output?
 
     @abstractmethod
     def backup(self) -> Path:
@@ -24,3 +24,19 @@ class BlackboxDatabase(BlackboxHandler):
         All subclasses must implement this method.
         """
         raise NotImplementedError
+
+    @property
+    def output(self):
+        """ Return sanitized output only """
+        return self.__output
+
+    @output.setter
+    def output(self, sensitive_output: str):
+        """ Set sanitized output """
+        self.__output = self.sanitize_output(sensitive_output)
+
+    def sanitize_output(self, output: str) -> str:
+        """ Replace all credentials with *** """
+        for sensitive_word in self.config.values():
+            output = output.replace(sensitive_word, "*" * len(sensitive_word))
+        return output

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -33,4 +33,4 @@ class BlackboxDatabase(BlackboxHandler):
     @output.setter
     def output(self, sensitive_output: str):
         """ Set sanitized output """
-        self.__output = self.sanitize_output(sensitive_output)
+        self.__output = self.sanitize_output(self.config, sensitive_output)

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -33,4 +33,4 @@ class BlackboxDatabase(BlackboxHandler):
     @output.setter
     def output(self, sensitive_output: str):
         """ Set sanitized output """
-        self.__output = self.sanitize_output(self.config, sensitive_output)
+        self.__output = self.sanitize_output(sensitive_output)

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -34,9 +34,3 @@ class BlackboxDatabase(BlackboxHandler):
     def output(self, sensitive_output: str):
         """ Set sanitized output """
         self.__output = self.sanitize_output(sensitive_output)
-
-    def sanitize_output(self, output: str) -> str:
-        """ Replace all credentials with *** """
-        for sensitive_word in self.config.values():
-            output = output.replace(sensitive_word, "*" * len(sensitive_word))
-        return output

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -27,10 +27,10 @@ class BlackboxDatabase(BlackboxHandler):
 
     @property
     def output(self):
-        """ Return sanitized output only """
+        """Return sanitized output only."""
         return self.__output
 
     @output.setter
     def output(self, sensitive_output: str):
-        """ Set sanitized output """
+        """Set sanitized output."""
         self.__output = self.sanitize_output(sensitive_output)

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -29,7 +29,7 @@ class SanitizeReportMixin:
         return sanitized_output
 
     @staticmethod
-    def extract_secrets(sensitive_words: [], mixed_secret) -> str:
+    def _extract_secrets(sensitive_words: list, mixed_secret) -> str:
         """ Helper method to get secrets values only """
         for database_name in mixed_secret:
             for secrets in database_name.values():

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -21,8 +21,7 @@ class SanitizeReportMixin:
 
         # now it's time to mask all secrets in our output
         for sensitive_word in set(sensitive_words):
-            sensitive_output = sensitive_output.replace(
-                sensitive_word, "*" * len(sensitive_word))
+            sensitive_output = sensitive_output.replace(sensitive_word, "*****")
 
         # emphasize output is clear now
         sanitized_output = sensitive_output

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -1,0 +1,9 @@
+class SanitizeReportMixin:
+    @staticmethod
+    def sanitize_output(config: dict, sensitive_output: str) -> str:
+        """ Replace all self.config credentials with in any str *** """
+        for sensitive_word in config.values():
+            sensitive_output = sensitive_output.replace(
+                sensitive_word, "*" * len(sensitive_word))
+        sanitized_output = sensitive_output  # emphasize output is clear now
+        return sanitized_output

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -1,9 +1,38 @@
+from blackbox.config import Blackbox as CONFIG
+from blackbox.utils.logger import log
+
+
 class SanitizeReportMixin:
-    @staticmethod
-    def sanitize_output(config: dict, sensitive_output: str) -> str:
+    """
+    Mixin class helper to mask all sensitive credentials
+
+    Could handle any string with sensitive output
+    """
+
+    def sanitize_output(self, sensitive_output: str) -> str:
         """ Replace all self.config credentials with in any str *** """
-        for sensitive_word in config.values():
+
+        # first of all let's combine list of secrets from config
+        sensitive_words = []
+        mixed_secrets = [CONFIG.databases.values(), CONFIG.storage.values(),
+                         CONFIG.notifiers.values(), ]
+        for mixed_secret in mixed_secrets:
+            self.extract_secrets(sensitive_words, mixed_secret)
+
+        # now it's time to mask all secrets in our output
+        for sensitive_word in set(sensitive_words):
             sensitive_output = sensitive_output.replace(
                 sensitive_word, "*" * len(sensitive_word))
-        sanitized_output = sensitive_output  # emphasize output is clear now
+
+        # emphasize output is clear now
+        sanitized_output = sensitive_output
+        log.success("Secrets are masked!")
         return sanitized_output
+
+    @staticmethod
+    def extract_secrets(sensitive_words: [], mixed_secret) -> str:
+        """ Helper method to get secrets values only """
+        for database_name in mixed_secret:
+            for secrets in database_name.values():
+                sensitive_words += list(secrets.values())
+        return sensitive_words

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -12,7 +12,6 @@ class SanitizeReportMixin:
 
     def sanitize_output(self, sensitive_output: str) -> str:
         """Replace all self.config credentials values with ***** in any string."""
-
         # First of all let's combine list of secrets from config.
         sensitive_words = self._extract_secrets()
 

--- a/blackbox/utils/reports.py
+++ b/blackbox/utils/reports.py
@@ -12,7 +12,7 @@ class StorageReport:
 
 
 @dataclasses.dataclass
-class DatabaseReport:
+class DatabaseReport(SanitizeReportMixin):
     """Keep database report."""
 
     database_id: str
@@ -23,7 +23,7 @@ class DatabaseReport:
     def report_storage(self, storage_id: str, success: bool, output: str):
         """Add a storage report to the current report."""
         # Add to database output
-        self.output += output
+        self.output += self.sanitize_output(output)
 
         # If one storage handler failed, the database backup is a failure.
         if success is False:

--- a/blackbox/utils/reports.py
+++ b/blackbox/utils/reports.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from blackbox.utils.mixins import SanitizeReportMixin
+
 
 @dataclasses.dataclass
 class StorageReport:
@@ -33,7 +35,7 @@ class DatabaseReport:
 
 
 @dataclasses.dataclass
-class Report:
+class Report(SanitizeReportMixin):
     """Keep combined report."""
 
     databases: list[DatabaseReport] = dataclasses.field(default_factory=list)
@@ -46,7 +48,7 @@ class Report:
     @property
     def output(self) -> str:
         """Return the combined outputs from all the database reports."""
-        return "\n".join(report.output for report in self.databases)
+        return self.sanitize_output("\n".join(report.output for report in self.databases))
 
     @property
     def is_empty(self) -> bool:


### PR DESCRIPTION
Resolved: #47 

In order to use sanitize method from literally everywhere I've created a mixin.
Custom method is simple as it could be: parse all credentials' values into list and check if output string contains it.
I add this mixin to `BlackboxHandler` so now `self.output` is sanitized on-the-fly using `@output.setter`
Adding this mixin to `DatabaseReport` helped to mask storage output.
Class `Report` is masking combined output. Now it is useless (we did it already) but in future it could contain some other than database output so it is additional precaution.

Example of word `blackbox` masked in output
![image](https://user-images.githubusercontent.com/67960818/113612457-8bb33c80-9658-11eb-9f32-39e40cefbe78.png)
