### PR TITLE
We now don't delete irrelevant files

### DIFF
--- a/blackbox/cli.py
+++ b/blackbox/cli.py
@@ -42,6 +42,7 @@ def run() -> bool:
 
         # Do a backup, then return the path to the backup file
         backup_file = database.backup()
+        database_id = database.get_id_for_retention()
         database.teardown()
 
         # Add report to notifiers
@@ -56,7 +57,7 @@ def run() -> bool:
         for storage in workflow.storage_providers:
             # Sync the provider, then rotate and cleanup
             storage.sync(backup_file)
-            storage.rotate()
+            storage.rotate(database_id)
             storage.teardown()
 
             # Store the outcome to the database report

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -14,7 +14,7 @@ class BlackboxDatabase(BlackboxHandler):
         super().__init__(**kwargs)
 
         self.success = False  # Was the backup successful?
-        self.output = ""  # What did the backup output?
+        self.output = ""      # What did the backup output?
 
     @abstractmethod
     def backup(self) -> Path:
@@ -34,3 +34,7 @@ class BlackboxDatabase(BlackboxHandler):
     def output(self, sensitive_output: str):
         """Set sanitized output."""
         self.__output = self.sanitize_output(sensitive_output)
+
+    def get_id_for_retention(self) -> str:
+        """Used for deleting only this kind of old backups."""
+        return self.config.get("id")

--- a/blackbox/handlers/storage/_base.py
+++ b/blackbox/handlers/storage/_base.py
@@ -50,7 +50,7 @@ class BlackboxStorage(BlackboxHandler):
         raise NotImplementedError
 
     @abstractmethod
-    def rotate(self):
+    def rotate(self, database_id: str):
         """
         Rotate the files in the storage provider.
 

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -105,13 +105,13 @@ class S3(BlackboxStorage):
         remote_objects = self.client.list_objects_v2(Bucket=self.bucket).get("Contents")
 
         # Filter their names with only this kind of database.
-        this_type_backups = [item for item in remote_objects
-                             if re.match(db_type_regex, item.get("Key"))]
+        relevant_backups = [item for item in remote_objects
+                            if re.match(db_type_regex, item.get("Key"))]
 
         # Look through the items and figure out which ones are older than `retention_days`.
         # Catch all boto errors and log them to avoid return code 1.
         try:
-            for item in this_type_backups:
+            for item in relevant_backups:
                 last_modified = item.get("LastModified")
                 now_tz = datetime.datetime.now(tz=last_modified.tzinfo)
                 delta = now_tz - item.get("LastModified")

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import re
 from pathlib import Path
 
 import boto3
@@ -38,7 +39,8 @@ class S3(BlackboxStorage):
         # If config was provided for only one of them, that's too weird of a state for us to accept,
         # so we'll raise an exception. (That weird ^ operator is an XOR).
         elif bool(key_id) ^ bool(secret_key):
-            raise ImproperlyConfigured("You must configure either both or none of the S3 credential params.")
+            raise ImproperlyConfigured(
+                "You must configure either both or none of the S3 credential params.")
 
         else:
             # If config hasn't been provided, we expect either environment variables or ~/.aws/
@@ -101,8 +103,13 @@ class S3(BlackboxStorage):
 
         # Look through the items and figure out which ones are older than `retention_days`.
         # Catch all boto errors and log them to avoid return code 1.
+        this_type_backups = [
+            item for item in self.client.list_objects_v2(
+                Bucket=self.bucket).get("Contents")
+            if re.match(db_type_regex, item.get("Key"))
+        ]
         try:
-            for item in self.client.list_objects(Bucket=self.bucket)["Contents"]:
+            for item in this_type_backups:
                 last_modified = item.get("LastModified")
                 now_tz = datetime.datetime.now(tz=last_modified.tzinfo)
                 delta = now_tz - item.get("LastModified")

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -86,7 +86,7 @@ class S3(BlackboxStorage):
             self.output = str(e)
             self.success = False
 
-    def rotate(self) -> None:
+    def rotate(self, database_id: str) -> None:
         """
         Rotate the files in the S3 bucket.
 
@@ -94,6 +94,7 @@ class S3(BlackboxStorage):
         those files fit certain regular expressions. We don't want to delete
         files that are not related to backup or logging.
         """
+        db_type_regex = rf"{database_id}_blackbox_\d{{2}}_\d{{2}}_\d{{4}}.+"
         retention_days = 7
         if Blackbox.retention_days:
             retention_days = Blackbox.retention_days


### PR DESCRIPTION
Resolves: #45 

This PR focuses on deleting proper files while performing `rotate` method of Storage.
Added `database_id` parameter with current id and using regex we work only with relevant backup files.
This PR implements new way of working in Dropbox and S3.
It is tested with Dropbox storage and DigitalOcean S3 Bucket.
No logic is changed, only filtering filenames' arrays.