### PR TITLE
Postgres and Redis are support now integer port values.

### DIFF
--- a/blackbox/handlers/databases/postgres.py
+++ b/blackbox/handlers/databases/postgres.py
@@ -9,7 +9,7 @@ from blackbox.utils.logger import log
 class Postgres(BlackboxDatabase):
     """A Database handler that will do a pg_dumpall for Postgres, backing up all tables."""
 
-    required_fields = ("username", "password", "host", "port")
+    required_fields = ("username", "password", "host", )
 
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
@@ -22,7 +22,7 @@ class Postgres(BlackboxDatabase):
             PGUSER=self.config["username"],
             PGPASSWORD=self.config["password"],
             PGHOST=self.config["host"],
-            PGPORT=self.config["port"],
+            PGPORT=str(self.config.get("port", "5432")),
         )
         log.debug(self.output)
 

--- a/blackbox/handlers/databases/redis.py
+++ b/blackbox/handlers/databases/redis.py
@@ -9,7 +9,7 @@ from blackbox.utils.logger import log
 class Redis(BlackboxDatabase):
     """A Database handler that will run a redis-cli command for Redis backup."""
 
-    required_fields = ("password", "host", "port")
+    required_fields = ("password", "host", )
 
     def backup(self) -> Path:
         """Dump all the data to a file and then return the filepath."""
@@ -20,7 +20,7 @@ class Redis(BlackboxDatabase):
         self.success, self.output = run_command(
             "redis-cli "
             f"-h {self.config.get('host')} "
-            f"-p {self.config.get('port')} "
+            f"-p {str(self.config.get('port', '6379'))} "
             f"--rdb {backup_path}",
             REDISCLI_AUTH=self.config.get("password")
         )


### PR DESCRIPTION
Resolves: #62 

And now port number is not required because we have default ports for popular databases: 5432 for postgres and 6379 for redis