### PR TITLE
Dropbox token error passes to output

### DIFF
--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -101,6 +101,10 @@ class Dropbox(BlackboxStorage):
         are older than `retention_days`, and because of this,
         it's better to have backups in isolated folder.
         """
+        # Check if Dropbox token is valid.
+        if self.valid is False:
+            log.warning("Dropbox token is invalid. Can't delete old backups")
+            return None
         # Let's rotate only this type of database
         db_type_regex = rf"{database_id}_blackbox_\d{{2}}_\d{{2}}_\d{{4}}.+"
 

--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -40,10 +40,10 @@ class Dropbox(BlackboxStorage):
         """Sync a file to Dropbox."""
         # Check if Dropbox token is valid.
         if self.valid is False:
-            error = "Dropbox token is invalid"
+            error = "Dropbox token is invalid!"
             self.success = False
             self.output = error
-            log.warning(error)
+            log.error(error)
             return None
 
         # This is size what can be uploaded as one chunk.
@@ -103,7 +103,7 @@ class Dropbox(BlackboxStorage):
         """
         # Check if Dropbox token is valid.
         if self.valid is False:
-            log.warning("Dropbox token is invalid. Can't delete old backups")
+            log.error("Dropbox token is invalid - Can't delete old backups!")
             return None
         # Let's rotate only this type of database
         db_type_regex = rf"{database_id}_blackbox_\d{{2}}_\d{{2}}_\d{{4}}.+"

--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from dropbox import Dropbox as DropboxClient
 from dropbox.exceptions import ApiError
+from dropbox.exceptions import AuthError
 from dropbox.exceptions import HttpError
 from dropbox.files import CommitInfo
 from dropbox.files import FileMetadata
@@ -26,9 +27,25 @@ class Dropbox(BlackboxStorage):
 
         self.upload_base = self.config.get("upload_directory") or "/"
         self.client = DropboxClient(self.config["access_token"])
+        self.valid = self._validate_token()
+
+    def _validate_token(self):
+        """Check if dropbox token is valid."""
+        try:
+            return self.client.check_user("test").result == "test"
+        except AuthError:
+            return False
 
     def sync(self, file_path: Path) -> None:
         """Sync a file to Dropbox."""
+        # Check if Dropbox token is valid.
+        if self.valid is False:
+            error = "Dropbox token is invalid"
+            self.success = False
+            self.output = error
+            log.warning(error)
+            return None
+
         # This is size what can be uploaded as one chunk.
         # When file is bigger than that, this will be uploaded
         # in multiple parts.


### PR DESCRIPTION
Just wrap it in `try` `except` and pass it to notifier.

Resolves: #65 
Now we see output and Blackbox is working even with bad Dropbox token.
![image](https://user-images.githubusercontent.com/67960818/114087590-bf8e9c00-98bc-11eb-8100-cb874d464ab3.png)
