### PR TITLE
Backup to a temporary folder instead of home directory

### DIFF
--- a/blackbox/cli.py
+++ b/blackbox/cli.py
@@ -4,9 +4,10 @@ Blackbox is a plug-and-play service which magically backs up all your databases.
 The backups are stored on your favorite cloud storage providers, and Blackbox will notify
 you on your chat platform of choice once the job is done.
 """
+import datetime
 import logging
-import os
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 import click
@@ -40,71 +41,68 @@ def run() -> bool:
 
     all_workflows = workflows.get_workflows(database_handlers, storage_handlers, notifier_handlers)
 
-    backup_files = []
+    with TemporaryDirectory() as backup_dir:
+        log.info(f"Backing up to folder: {backup_dir}")
+        backup_dir = Path(backup_dir)
+        date = datetime.date.today().strftime("%d_%m_%Y")
+        backup_files = []
 
-    for workflow in all_workflows:
-        database = workflow.database
+        for workflow in all_workflows:
+            database = workflow.database
 
-        # Do a backup, then return the path to the backup file
-        backup_file = database.backup()
-        backup_files.append(backup_file)
-        database_id = database.get_id_for_retention()
-        database.teardown()
+            # Do a backup, then return the path to the backup file
+            backup_path = backup_dir / f"{database.config['id']}_blackbox_{date}{database.backup_extension}"
+            database.backup(backup_path)
+            backup_files.append(backup_path)
+            database_id = database.get_id_for_retention()
+            database.teardown()
 
-        # Add report to notifiers
-        report = DatabaseReport(database.config["id"], database.success, database.output)
-        for notifier in workflow.notifiers:
-            notifier.add_database(report)
+            # Add report to notifiers
+            report = DatabaseReport(database.config["id"], database.success, database.output)
+            for notifier in workflow.notifiers:
+                notifier.add_database(report)
 
-        # If backup failed, continue to next database. No need to sync.
-        if not database.success:
-            continue
+            # If backup failed, continue to next database. No need to sync.
+            if not database.success:
+                continue
 
-        for storage in workflow.storage_providers:
-            # Sync the provider, then rotate and cleanup
-            storage.sync(backup_file)
-            storage.rotate(database_id)
-            storage.teardown()
+            for storage in workflow.storage_providers:
+                # Sync the provider, then rotate and cleanup
+                storage.sync(backup_path)
+                storage.rotate(database_id)
+                storage.teardown()
 
-            # Store the outcome to the database report
-            report.report_storage(storage.config["id"], storage.success, storage.output)
+                # Store the outcome to the database report
+                report.report_storage(storage.config["id"], storage.success, storage.output)
 
-        # Set overall program success to False if workflow is unsuccessful
-        if report.success is False:
-            success = False
+            # Set overall program success to False if workflow is unsuccessful
+            if report.success is False:
+                success = False
 
-    cooldown = CONFIG['cooldown']
-    logging.debug(f"Cooldown setting is {cooldown}")
-    if cooldown:
-        is_on_cooldown_ = is_on_cooldown(cooldown)
+        cooldown = CONFIG['cooldown']
+        logging.debug(f"Cooldown setting is {cooldown}")
+        if cooldown:
+            is_on_cooldown_ = is_on_cooldown(cooldown)
 
-    # Send a report for each notifier configured
-    for notifier in notifier_handlers["all"]:
-        # Don't send a notification if no database uses the notifier
-        if notifier.report.is_empty:
-            continue
+        # Send a report for each notifier configured
+        for notifier in notifier_handlers["all"]:
+            # Don't send a notification if no database uses the notifier
+            if notifier.report.is_empty:
+                continue
 
-        # If cooldown is not set or if report is failed: just notify.
+            # If cooldown is not set or if report is failed: just notify.
 
-        if cooldown is None or not notifier.report.success:
-            log.debug('Config not found or backup failed, sending notification.')
-            notifier.notify()
-
-        # But otherwise let's check do we have a right to notify
-        else:
-            if not is_on_cooldown_:
+            if cooldown is None or not notifier.report.success:
+                log.debug('Config not found or backup failed, sending notification.')
                 notifier.notify()
 
-        notifier.teardown()
+            # But otherwise let's check do we have a right to notify
+            else:
+                if not is_on_cooldown_:
+                    notifier.notify()
 
-    # Clean up databases backups.
-    for file in backup_files:
-        try:
-            os.remove(file)
-            log.info(f"{file} deleted.")
-        except OSError:
-            log.info(f"{file} is not deleted.")
-    return success
+            notifier.teardown()
+        return success
 
 
 @click.command()

--- a/blackbox/cli.py
+++ b/blackbox/cli.py
@@ -91,7 +91,6 @@ def run() -> bool:
                 continue
 
             # If cooldown is not set or if report is failed: just notify.
-
             if cooldown is None or not notifier.report.success:
                 log.debug('Config not found or backup failed, sending notification.')
                 notifier.notify()

--- a/blackbox/handlers/databases/_base.py
+++ b/blackbox/handlers/databases/_base.py
@@ -8,6 +8,7 @@ class BlackboxDatabase(BlackboxHandler):
     """An abstract database handler."""
 
     handler_type = "database"
+    backup_extension = ""
 
     def __init__(self, **kwargs):
         """Set up database handler."""
@@ -17,9 +18,9 @@ class BlackboxDatabase(BlackboxHandler):
         self.output = ""      # What did the backup output?
 
     @abstractmethod
-    def backup(self) -> Path:
+    def backup(self, backup_path: Path):
         """
-        Back up a database and return the Path for the backup file.
+        Back up a database to the provided backup Path.
 
         All subclasses must implement this method.
         """

--- a/blackbox/handlers/databases/mariadb.py
+++ b/blackbox/handlers/databases/mariadb.py
@@ -1,6 +1,3 @@
-import datetime
-from pathlib import Path
-
 from blackbox.handlers.databases._base import BlackboxDatabase
 from blackbox.utils import run_command
 from blackbox.utils.logger import log
@@ -10,17 +7,14 @@ class MariaDB(BlackboxDatabase):
     """A Database handler that will do a mysqldump for MariaDB, backing up all tables."""
 
     required_fields = ("username", "password", "host", )
+    backup_extension = ".sql"
 
-    def backup(self) -> Path:
+    def backup(self, backup_path) -> None:
         """Dump all the data to a file and then return the filepath."""
-        date = datetime.date.today().strftime("%d_%m_%Y")
-
         user = self.config["username"]
         password = self.config["password"]
         host = self.config["host"]
         port = str(self.config.get("port", "3306"))
-
-        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.sql"
 
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(
@@ -33,6 +27,3 @@ class MariaDB(BlackboxDatabase):
         if "error" in self.output.lower():
             self.success = False
             log.debug("mysqldump has error(s) in log")
-
-        # Return the path to the backup file
-        return backup_path

--- a/blackbox/handlers/databases/mongodb.py
+++ b/blackbox/handlers/databases/mongodb.py
@@ -1,6 +1,3 @@
-import datetime
-from pathlib import Path
-
 from blackbox.handlers.databases._base import BlackboxDatabase
 from blackbox.utils import run_command
 from blackbox.utils.logger import log
@@ -15,21 +12,16 @@ class MongoDB(BlackboxDatabase):
     """
 
     required_fields = ("connection_string",)
+    backup_extension = ".archive"
 
-    def backup(self) -> Path:
+    def backup(self, backup_path) -> None:
         """Dump all the data to a file and then return the filepath."""
-        date = datetime.date.today().strftime("%d_%m_%Y")
-        archive_file = Path.home() / f"{self.config['id']}_blackbox_{date}.archive"
-
         # Run the backup, and store the outcome in this object.
         self.success, self.output = run_command(
             f"mongodump "
             f"--uri={self.config['connection_string']} "
             "--gzip "
             "--forceTableScan "
-            f"--archive={archive_file}"
+            f"--archive={backup_path}"
         )
         log.debug(self.output)
-
-        # Return the path to the backup file
-        return archive_file

--- a/blackbox/handlers/databases/postgres.py
+++ b/blackbox/handlers/databases/postgres.py
@@ -1,6 +1,3 @@
-import datetime
-from pathlib import Path
-
 from blackbox.handlers.databases._base import BlackboxDatabase
 from blackbox.utils import run_command
 from blackbox.utils.logger import log
@@ -10,12 +7,10 @@ class Postgres(BlackboxDatabase):
     """A Database handler that will do a pg_dumpall for Postgres, backing up all tables."""
 
     required_fields = ("username", "password", "host", )
+    backup_extension = ".sql"
 
-    def backup(self) -> Path:
+    def backup(self, backup_path) -> None:
         """Dump all the data to a file and then return the filepath."""
-        date = datetime.date.today().strftime("%d_%m_%Y")
-        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.sql"
-
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(
             f"pg_dumpall --file={backup_path}",
@@ -25,6 +20,3 @@ class Postgres(BlackboxDatabase):
             PGPORT=str(self.config.get("port", "5432")),
         )
         log.debug(self.output)
-
-        # Return the path to the backup file
-        return backup_path

--- a/blackbox/handlers/databases/redis.py
+++ b/blackbox/handlers/databases/redis.py
@@ -1,6 +1,3 @@
-import datetime
-from pathlib import Path
-
 from blackbox.handlers.databases._base import BlackboxDatabase
 from blackbox.utils import run_command
 from blackbox.utils.logger import log
@@ -10,12 +7,10 @@ class Redis(BlackboxDatabase):
     """A Database handler that will run a redis-cli command for Redis backup."""
 
     required_fields = ("password", "host", )
+    backup_extension = ".rdb"
 
-    def backup(self) -> Path:
+    def backup(self, backup_path) -> None:
         """Dump all the data to a file and then return the filepath."""
-        date = datetime.date.today().strftime("%d_%m_%Y")
-        backup_path = Path.home() / f"{self.config['id']}_blackbox_{date}.rdb"
-
         # Run the backup, and store the outcome.
         self.success, self.output = run_command(
             "redis-cli "
@@ -25,6 +20,3 @@ class Redis(BlackboxDatabase):
             REDISCLI_AUTH=self.config.get("password")
         )
         log.debug(self.output)
-
-        # Return the path to the backup file
-        return backup_path

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -38,7 +38,7 @@ def test_mongodb_backup(mock_valid_mongodb_config, fake_process):
     mongo = MongoDB(**mock_valid_mongodb_config)
 
     date = datetime.datetime.today().strftime("%d_%m_%Y")
-    archive = Path.home() / f"main_mongo_blackbox_{date}.archive"
+    archive = Path.cwd() / f"main_mongo_blackbox_{date}.archive"
 
     command_to_run = [
         f"mongodump --uri=mongodb://mongouser:mongopassword@host:port --gzip --forceTableScan --archive={archive}"
@@ -48,6 +48,5 @@ def test_mongodb_backup(mock_valid_mongodb_config, fake_process):
         command_to_run, stdout=["thing", "stuff"]
     )
 
-    res = mongo.backup()
-
-    assert res == archive
+    mongo.backup(archive)
+    assert fake_process.call_count(command_to_run) == 1

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -45,6 +45,5 @@ def test_postgres_backup(mock_valid_postgres_config, fake_process):
         command_to_run, stdout=["thing", "stuff"]
     )
 
-    res = postgres.backup()
-
-    assert res == backup_path
+    postgres.backup(backup_path)
+    assert fake_process.call_count(command_to_run) == 1

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -46,6 +46,5 @@ def test_redis_backup(mock_valid_redis_config, fake_process):
         command_to_run, stdout=["redis backup"]
     )
 
-    res = redis.backup()
-
-    assert res == backup_path
+    redis.backup(backup_path)
+    assert fake_process.call_count(command_to_run) == 1


### PR DESCRIPTION
Closes #88 

This PR makes files be backed up to an OS provided temporary file for more safety, as the files will be automatically cleared in case of a failure.

It also changes the `Handler.backup()` function to take the path of the file as an argument. This is made to avoid repeating the file name generation code everywhere and make sure that they end up in the temp folder.
A `backup_extension` class attribute has been added to the `Handler` class to be appended at the end of each file, to keep correct extensions.