### PR TITLE
lemon/even simpler semantic versioning

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,12 +5,38 @@ on:
     types: [ published ]
 
 jobs:
-  publish-to-pipy:
-    name: publish to pypi.org
+  bump-pyproject-version:
+    name: Bump pyproject version
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout the repo and the submodules.
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Bump the version
+        run: poetry version ${{ github.event.release.tag_name }}
+
+      - name: Commit the changes
+        run: |
+          git add pyproject.toml
+          git commit -m "Bump version to ${{ github.event.release.tag_name }}"
+          git push origin main
+
+  publish-to-pipy:
+    name: Publish to pypi.org
+    runs-on: ubuntu-latest
+    needs: bump-pyproject-version
+
+    steps:
+      - name: Checkout the repo.
         uses: actions/checkout@v2
 
       - name: Set up Python
@@ -18,16 +44,11 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install Poetry >= 1.2.0a
-        run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -O &&
-          python install-poetry.py --preview
+      - name: Install poetry
+        run: pip install poetry
 
       - name: Install dependencies
         run: poetry install
-
-      - name: Install poetry-version-plugin
-        run: poetry plugin add poetry-version-plugin
 
       - name: Build and publish to pypi
         run: |
@@ -35,7 +56,7 @@ jobs:
           poetry publish --build
 
   build-and-push-on-release:
-    name: Build and push
+    name: Build and push to DockerHub
     runs-on: ubuntu-latest
     needs: publish-to-pipy
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,4 +33,4 @@ jobs:
         run: poe lint
 
       - name: Testing
-        run: poe test
+        run: poe tests

--- a/blackbox/__init__.py
+++ b/blackbox/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+from single_source import get_version
+
+__version__ = get_version(__name__, Path(__file__).parent.parent)

--- a/blackbox/cli.py
+++ b/blackbox/cli.py
@@ -105,14 +105,20 @@ def run() -> bool:
 
 
 @click.command()
-@click.option('--config', help="Path to blackbox.yaml file")
-@click.option('--init', is_flag=True, help="Generate blackbox.yaml file and exit")
-def cli(config, init):
+@click.option('--config', help="Path to blackbox.yaml file.")
+@click.option('--init', is_flag=True, help="Generate blackbox.yaml file and exit.")
+@click.option('--version', is_flag=True, help="Show version and exit.")
+def cli(config, init, version):
     """
     BLACKBOX
 
     Backup database to external storage system
     """  # noqa
+    if version:
+        from blackbox import __version__
+        print(f"Blackbox {__version__}")
+        exit()
+
     if init:
         config_file = Path("blackbox.yaml")
         if not config_file.exists():

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,7 +2,7 @@
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -10,7 +10,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "20.3.0"
 description = "Classes Without Boilerplate"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -103,7 +103,6 @@ python-versions = "*"
 [package.dependencies]
 requests = ">=2.16.2"
 six = ">=1.12.0"
-stone = ">=2"
 
 [[package]]
 name = "flake8"
@@ -146,7 +145,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -220,7 +219,7 @@ python-versions = "*"
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -239,7 +238,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -270,7 +269,7 @@ tomlkit = ">=0.6.0,<1.0.0"
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -294,7 +293,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -317,7 +316,7 @@ redis = ["redis (>=3.4.1)"]
 name = "pytest"
 version = "6.2.3"
 description = "pytest: simple powerful testing with Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -383,7 +382,7 @@ test = ["pytest (>=4.0)", "coverage", "docutils (>=0.12)", "Pygments (>=2.0)", "
 name = "pytest-testdox"
 version = "2.0.1"
 description = "A testdox format reporter for pytest"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -455,6 +454,14 @@ python-versions = "*"
 botocore = ">=1.12.36,<2.0a.0"
 
 [[package]]
+name = "single-source"
+version = "0.2.0"
+description = "Access to the project version in Python code for PEP 621-style projects"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -491,7 +498,7 @@ test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybi
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -530,7 +537,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "26c498368d51234dd1570157df3b76a230f3c4f68cde5caaf79d7c56bd128b52"
+content-hash = "485a8e27e709b9f83aab9e160a306186f884f6c84744fef07eb49faa5ca93b29"
 
 [metadata.files]
 atomicwrites = [
@@ -819,6 +826,10 @@ requests-mock = [
 s3transfer = [
     {file = "s3transfer-0.3.6-py2.py3-none-any.whl", hash = "sha256:5d48b1fd2232141a9d5fb279709117aaba506cacea7f86f11bc392f06bfa8fc2"},
     {file = "s3transfer-0.3.6.tar.gz", hash = "sha256:c5dadf598762899d8cfaecf68eba649cd25b0ce93b6c954b156aaa3eed160547"},
+]
+single-source = [
+    {file = "single-source-0.2.0.tar.gz", hash = "sha256:f40f94c7f2e72c854b9c0c6f7d6b545d74ada9ebd454f9f07f8fb743b22bccf5"},
+    {file = "single_source-0.2.0-py3-none-any.whl", hash = "sha256:82c55b00515a30c8f7c262b986a399ca023911ebb6a86f0953d4c50448c36b16"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,21 +35,19 @@ single-source = "^0.2.0"
 stone = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
+flake8 = "^3.9.0"
+flake8-isort = "^4.0.0"
 pytest = "*"
 pytest-cov = "^2.11.1"
 pytest-mock = "^3.5.1"
-flake8 = "^3.9.0"
-flake8-isort = "^4.0.0"
 pytest-subprocess = "^1.0.1"
+pytest-testdox = "^2.0.1"
+poethepoet = "^0.10.0"
 requests-mock = "^1.8.0"
 win32-setctime = "^1.0.3"
-poethepoet = "^0.10.0"
-
-[tool.poetry-version-plugin]
-source = "git-tag"
 
 [build-system]
-requires = ["poetry-core>=1.1.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "blackbox-cli"
 packages = [
     { include = "blackbox" }
 ]
-version = "0"  # This is not in use. The version is fetched from the most recent git tag.
+version = "2.1.5"
 description = "Tool for automatic backups of databases"
 authors = ["Leon Sandøy <leon.sandoy@gmail.com>"]
 license = "MIT"
@@ -31,7 +31,8 @@ jinja2 = "^2.11.2"
 click = "^7.1.2"
 dropbox = "^11.0.0"
 pytelegrambotapi = "^3.7.7"
-pytest-testdox = "^2.0.1"
+single-source = "^0.2.0"
+stone = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 blackbox = "blackbox.cli:cli"
 
+# Use 'poetry run poe <taskname>' to run these.
 [tool.poe.tasks]
-test = "pytest --cov blackbox -vv --cov-report=term-missing ."
+tests = "pytest --cov blackbox -vv --cov-report=term-missing ."
 lint = "flake8 ."
 isort = "isort ."
 html = "pytest --cov blackbox --cov-report=html ."

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
- Just get rid of setup.py. We don't need editable installs.
- poe tests instead of poe test.
- Use single-source to fetch version for --version.
- Clean up dependencies.
- Bump the version on release.
