### PR TITLE
Readme: switch to batch/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ at midnight.
 
 ```yaml
 # cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: blackbox


### PR DESCRIPTION
`batch/v1beta1` has been deprecated by Kubernetes for a few releases now, and will be removed in a later version. This commit changes the example to `batch/v1`.