### PR TITLE
Add support for PostgreSQL 15.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   postgres:
     container_name: blackbox-postgres
-    image: postgres:14
+    image: postgres:15
     environment:
       POSTGRES_USER: blackbox
       POSTGRES_PASSWORD: blackbox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,12 +24,12 @@ RUN wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2004-x
 # Install redis-tools, used for redis backups.
 RUN apt install -y redis-tools
 
-# Install the Postgres 14 client, needed for pg_dumpall
+# Install the Postgres 15 client, needed for pg_dumpall
 # And MariaDB client for mysqldump
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update -y && \
-    apt-get install -y postgresql-client-14 mariadb-client
+    apt-get install -y postgresql-client-15 mariadb-client
 
 # Create and set the working directory, so we don't make a mess in the Docker filesystem.
 WORKDIR /blackbox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y update && apt-get install -y \
 # Install and setup poetry
 RUN pip install -U pip \
     && apt install -y curl \
-    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+    && curl -sSL https://install.python-poetry.org | POETRY_HOME=/root/.poetry python
 ENV PATH="${PATH}:/root/.poetry/bin"
 
 # Install mongotools, used for getting mongo backups


### PR DESCRIPTION
* Update Docker image in docker-compose.yaml
* Update client tooling used in Dockerfile
* Use the new poetry installer

The old poetry installer now errors if you don't also specify an old version of poetry to install.

The newer installer also changes the path that poetry is installed to by default, so I have used POETRY_HOME to ensure the path remains the same.