### PR TITLE
adding support for arm64 container 

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -22,9 +22,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
       # Set up Docker Buildx and log into DockerHub
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,18 @@ RUN pip install -U pip \
 ENV PATH="${PATH}:/root/.poetry/bin"
 
 # Install mongotools, used for getting mongo backups
-RUN wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2004-x86_64-100.5.0.deb -O mongo-tools.deb \
-    && apt install -y ./mongo-tools.deb
+RUN <<-EOF
+architecture=""
+    case $(uname -m) in
+        x86_64) architecture="amd64" ;;
+        x86_64) architecture="amd64" ;;
+        arm64) architecture="arm64" ;;
+        aarch64) architecture="arm64" ;;
+    esac
+    wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2004-${architecture}-100.6.1.deb -O mongo-tools.deb
+    apt install -y ./mongo-tools.deb
+    rm ./mongo-tools.deb
+EOF
 
 # Install redis-tools, used for redis backups.
 RUN apt install -y redis-tools


### PR DESCRIPTION
- update mongotdb tools version to version 100.6.1
- build and publish arm64 containers

arm64 architecture has gotten more popular in the last years e.g. Apple M1/M2 CPUs, RaspberryPi and most cloud providers are offereing arm-based instances.

The steps in the CI are taken from the official Docker documentation: https://docs.docker.com/build/ci/github-actions/multi-platform/

I successfully build the container on arm64 and amd64 using the following command:
`DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t blackbox:latest .`
(docker buildkit is required now because of the multiline shell script). This could also be converted to an external script or refactored to not require buildkit.
