### PR TITLE
Bump PostgreSQL to version 16

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   postgres:
     container_name: blackbox-postgres
-    image: postgres:15
+    image: postgres:16
     environment:
       POSTGRES_USER: blackbox
       POSTGRES_PASSWORD: blackbox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,12 +32,12 @@ EOF
 # Install redis-tools, used for redis backups.
 RUN apt install -y redis-tools
 
-# Install the Postgres 15 client, needed for pg_dumpall
+# Install the Postgres 16 client, needed for pg_dumpall
 # And MariaDB client for mysqldump
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update -y && \
-    apt-get install -y postgresql-client-15 mariadb-client
+    apt-get install -y postgresql-client-16 mariadb-client
 
 # Create and set the working directory, so we don't make a mess in the Docker filesystem.
 WORKDIR /blackbox


### PR DESCRIPTION
Bumps PostgreSQL to version 16, the latest stable version of PG.

We recently upgraded the PyDis image so blackbox is currently failing.
