### PR TITLE
Support any rotation strategy

### DIFF
--- a/blackbox/config.py
+++ b/blackbox/config.py
@@ -98,7 +98,7 @@ class YAMLGetter(type):
             # If one of the handler lists isn't defined, return an empty list.
             log.warning(
                 f"{name} is not defined in the blackbox.yaml file -- "
-                "returning an falsy value."
+                "returning a falsy value."
             )
             if cls._get_annotation(name) == list:
                 return []

--- a/blackbox/handlers/storage/_base.py
+++ b/blackbox/handlers/storage/_base.py
@@ -102,7 +102,8 @@ class BlackboxStorage(BlackboxHandler):
             # Backup doesn't match any of the retention configs (whether using retention
             # days or rotation strategies) - delete it!
             self._delete_backup(file_id=file_id)
-        else:
+
+        elif self.rotation_strategies:
             # Determine whether we should delete this backup, based on the rotation
             # strategies config representing the maximum number of backups to retain
             if len(retention_config_matches) == 1:
@@ -134,11 +135,11 @@ class BlackboxStorage(BlackboxHandler):
                 dt=modified_time,
             ):
                 self._delete_backup(file_id=file_id)
-
-            # Otherwise, we've retained the backup, so we should increment the
-            # corresponding expression(s) in our retention tracker
-            for exp in retention_config_matches:
-                self.backups_retained[exp]["num_retained"] += 1
+            else:
+                # Otherwise, we've retained the backup, so we should increment the
+                # corresponding expression(s) in our retention tracker
+                for exp in retention_config_matches:
+                    self.backups_retained[exp]["num_retained"] += 1
 
     @abstractmethod
     def _delete_backup(self, file_id: str) -> None:

--- a/blackbox/handlers/storage/_base.py
+++ b/blackbox/handlers/storage/_base.py
@@ -127,7 +127,6 @@ class BlackboxStorage(BlackboxHandler):
             #   retention_days is not configured
             #   OR retention_days is configured, but the retention window has passed
             num_retained = self.backups_retained[highest_expression]["num_retained"]
-
             if rotation.meets_delete_criteria(
                 max_to_retain=maximum,
                 num_retained=num_retained,

--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -130,6 +130,13 @@ class Dropbox(BlackboxStorage):
             entries += [entry for entry in files_result.entries if
                         self._is_backup_file(entry, db_type_regex)]
 
+        # Sort the backups in order of most recent to last.
+        entries = sorted(
+            entries,
+            key=lambda entry: entry.server_modified,
+            reverse=True,
+        )
+
         # Find all old files and delete them.
         for item in entries:
             last_modified = item.server_modified

--- a/blackbox/handlers/storage/dropbox.py
+++ b/blackbox/handlers/storage/dropbox.py
@@ -1,6 +1,5 @@
 import os
 import re
-from datetime import datetime
 from pathlib import Path
 
 from dropbox import Dropbox as DropboxClient
@@ -12,7 +11,6 @@ from dropbox.files import FileMetadata
 from dropbox.files import UploadSessionCursor
 from dropbox.files import WriteMode
 
-from blackbox.config import Blackbox
 from blackbox.handlers.storage._base import BlackboxStorage
 from blackbox.utils.logger import log
 
@@ -35,6 +33,16 @@ class Dropbox(BlackboxStorage):
             return self.client.check_user("test").result == "test"
         except AuthError:
             return False
+
+    def _delete_backup(self, file_id: str) -> None:
+        """
+        Delete a backup file.
+
+        Args
+            file_id: The file's identifier. For Dropbox, this would be the file path.
+        """
+
+        self.client.files_delete(path=file_id)
 
     def sync(self, file_path: Path) -> None:
         """Sync a file to Dropbox."""
@@ -122,17 +130,10 @@ class Dropbox(BlackboxStorage):
             entries += [entry for entry in files_result.entries if
                         self._is_backup_file(entry, db_type_regex)]
 
-        retention_days = 7
-        if Blackbox.retention_days:
-            retention_days = Blackbox.retention_days
-
         # Find all old files and delete them.
         for item in entries:
             last_modified = item.server_modified
-            now = datetime.now(tz=last_modified.tzinfo)
-            delta = now - last_modified
-            if delta.days >= retention_days:
-                self.client.files_delete(item.path_lower)
+            self._do_rotate(file_id=item.path_lower, modified_time=last_modified)
 
     @staticmethod
     def _is_backup_file(entry, db_type_regex) -> bool:

--- a/blackbox/handlers/storage/google_drive.py
+++ b/blackbox/handlers/storage/google_drive.py
@@ -227,7 +227,6 @@ class GoogleDrive(BlackboxStorage):
 
     def _delete_backup(self, file_id: str) -> None:
         """Delete a backup file."""
-        print("running _delete_backup")
         self.client.files().delete(fileId=file_id).execute()
 
     def sync(self, file_path: Path) -> None:

--- a/blackbox/handlers/storage/google_drive.py
+++ b/blackbox/handlers/storage/google_drive.py
@@ -277,7 +277,7 @@ class GoogleDrive(BlackboxStorage):
             self.output = str(e)
 
         else:
-            # Delete database backups that are do not match the user's retention config
+            # Delete database backups that do not match the user's retention config
             for file_ in files:
                 if re.match(db_type_regex, file_["name"]):
                     last_modified = file_["modifiedTime"]

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import re
 from pathlib import Path
@@ -7,7 +6,6 @@ import boto3
 from botocore.exceptions import BotoCoreError
 from botocore.exceptions import ClientError
 
-from blackbox.config import Blackbox
 from blackbox.exceptions import ImproperlyConfigured
 from blackbox.handlers.storage._base import BlackboxStorage
 from blackbox.utils.logger import log
@@ -71,6 +69,19 @@ class S3(BlackboxStorage):
             endpoint_url=f"https://{self.endpoint}",
         )
 
+    def _delete_backup(self, file_id: str) -> None:
+        """
+        Delete a backup file.
+
+        Args
+            file_id: The identifier of the file. For S3, this would be its Key.
+        """
+
+        self.client.delete_object(
+            Bucket=self.bucket,
+            Key=file_id,
+        )
+
     def sync(self, file_path: Path) -> None:
         """Sync a file to an S3 bucket."""
         file_, recompressed = self.compress(file_path)
@@ -97,9 +108,6 @@ class S3(BlackboxStorage):
         files that are not related to backup or logging.
         """
         db_type_regex = rf"{database_id}_blackbox_\d{{2}}_\d{{2}}_\d{{4}}.+"
-        retention_days = 7
-        if Blackbox.retention_days:
-            retention_days = Blackbox.retention_days
 
         # Get files object from remote S3 bucket.
         remote_objects = self.client.list_objects_v2(Bucket=self.bucket).get("Contents")
@@ -113,14 +121,6 @@ class S3(BlackboxStorage):
         try:
             for item in relevant_backups:
                 last_modified = item.get("LastModified")
-                now_tz = datetime.datetime.now(tz=last_modified.tzinfo)
-                delta = now_tz - item.get("LastModified")
-
-                # Delete the deprecated items
-                if delta.days >= retention_days:
-                    self.client.delete_object(
-                        Bucket=self.bucket,
-                        Key=item.get("Key")
-                    )
+                self._do_rotate(file_id=item.get("Key"), modified_time=last_modified)
         except (ClientError, BotoCoreError) as e:
             log.error(e)

--- a/blackbox/handlers/storage/s3.py
+++ b/blackbox/handlers/storage/s3.py
@@ -77,10 +77,7 @@ class S3(BlackboxStorage):
             file_id: The identifier of the file. For S3, this would be its Key.
         """
 
-        self.client.delete_object(
-            Bucket=self.bucket,
-            Key=file_id,
-        )
+        self.client.delete_object(Bucket=self.bucket, Key=file_id)
 
     def sync(self, file_path: Path) -> None:
         """Sync a file to an S3 bucket."""

--- a/blackbox/utils/mixins.py
+++ b/blackbox/utils/mixins.py
@@ -34,5 +34,8 @@ class SanitizeReportMixin:
         for blackbox_type in types:
             for kind in blackbox_type:
                 for unique_id in kind.values():
-                    sensitive_words += list(unique_id.values())
+                    sensitive_words += [
+                        val if not isinstance(val, list) else ",".join(val)
+                        for val in unique_id.values()
+                    ]
         return sensitive_words

--- a/blackbox/utils/rotation.py
+++ b/blackbox/utils/rotation.py
@@ -1,0 +1,190 @@
+"""Handler-agnostic cron and rotation strategy helper functions."""
+from datetime import datetime
+from typing import Tuple
+
+
+def matches_crons(cron_expressions: list[str], dt: datetime) -> list[str]:
+    """
+    Check if the given datetime matches at least one of the provided cron expressions.
+
+    Args:
+        cron_expressions: A list of cron expressions, cleaned to ensure only 5 "parts".
+        dt: Datetime to check.
+
+    Returns:
+        A list of matching cron expressions.
+    """
+
+    matches = []
+    for exp in cron_expressions:
+        if matches_cron(cron_expression=exp, dt=dt):
+            matches.append(exp)
+    return matches
+
+
+def matches_cron(cron_expression: str, dt: datetime) -> bool:
+    """
+    Check if the given datetime matches the cron expression.
+
+    Args
+        cron_expression: Cron expression.
+        dt: Datetime to check.
+    Return
+        True if the datetime fits within the cron expression, False otherwise.
+    """
+
+    # Get the different pieces of the datetime to match against the cron expression
+    minute, hour, day, month = dt.minute, dt.hour, dt.day, dt.month
+    # We need to use isoweekday here, because cron expressions use 7 for Sunday, whereas
+    # Python's datetime.weekday() represents Sunday as 6
+    weekday = dt.isoweekday()
+
+    parts = cron_expression.split()
+    if len(parts) != 5:
+        raise ValueError(
+            f"Invalid cron expression (should have 5 fields): {cron_expression}")
+    cron_min, cron_hour, cron_day, cron_month, cron_weekday = parts
+
+    # Check if each cron expression "part" matches the corresponding datetime "part"
+    return (
+        match_field(minute, cron_min)
+        and match_field(hour, cron_hour)
+        and match_field(day, cron_day)
+        and match_field(month, cron_month)
+        and match_field(weekday, cron_weekday, is_weekday=True)
+    )
+
+
+def match_field(value: int, field: str, is_weekday: bool = False) -> bool:
+    """
+    Match a cron expression field to a datetime "part" value.
+
+    Args
+        value: A datetime "part" value. ex. 12 for day, 3 for hour, etc.
+        field: The value of the cron expression field corresponding with the datetime
+            value. ex. If the datetime is 2025, 2, 23, 6, 12, 45, 17, and the cron
+            expression is * * * 3 *, and the `value` arg is 2, the `field` arg should
+            be 3.
+        is_weekday: Whether the cron expression field we are evaluating is a weekday.
+
+    Return
+        Whether the provided value matches or falls within the range of the the cron
+        expression field.
+    """
+
+    # For weekday, allow both 0 and 7 to represent Sunday
+    if is_weekday and field == "0":
+        field = "7"
+
+    # Wildcard matches any value
+    if field == "*":
+        return True
+
+    # Comma-separated list, ex. "1,5,10"
+    if "," in field:
+        options = []
+        for part in field.split(","):
+            part = part.strip()
+            if is_weekday and part == "0":
+                options.append(7)
+            else:
+                options.append(int(part))
+        return value in options
+
+    # Ranges, ex. "1-5"
+    if "-" in field:
+        start_str, end_str = field.split("-")
+        start = int(start_str) if not (is_weekday and start_str == "0") else 7
+        end = int(end_str) if not (is_weekday and end_str == "0") else 7
+        return start <= value <= end
+
+    # Step values, ex. "*/15" or "5/10"
+    if "/" in field:
+        base, step_str = field.split("/")
+        step = int(step_str)
+        if base == "*":
+            return value % step == 0
+        else:
+            base_val = int(base)
+            return (value - base_val) % step == 0
+
+    # Direct number match
+    try:
+        return value == int(field)
+    except ValueError:
+        raise ValueError(f"Cannot parse field: {field}")
+
+
+def within_retention_days(days: int, dt: datetime) -> bool:
+    """Return whether the provided datetime is between now and `days` days ago."""
+    now = datetime.now(tz=dt.tzinfo)
+    delta = now - dt
+    return delta.days <= days
+
+
+def construct_retention_tracker(
+    cron_expressions: list[str],
+) -> dict[str, dict[str, int]]:
+    """Construct a dictionary tracking how many retentions have occurred for a file
+    matching each cron expression."""
+    unlimited = 999999  # Who's actually going to have 999999 backups? Probably no-one.
+    tracker = {}
+    if not cron_expressions:
+        return {}  # No expressions configured
+    for exp in cron_expressions:
+        exp = exp.split()
+        if len(exp) == 6:
+            num_to_retain = exp.pop()
+            try:
+                num_to_retain = int(num_to_retain)
+            except ValueError:
+                # This will happen if the num to retain config is not an integer, ex. if
+                # its value is "*" (the wild card). If the value is something silly,
+                # retain unlimited backups, to err on the side of caution.
+                num_to_retain = unlimited
+        else:
+            # The user did not include a 6th value, so assume unlimited
+            num_to_retain = unlimited
+        exp = " ".join(exp)
+        tracker[exp] = {
+            "num_retained": 0,
+            "max": num_to_retain,
+        }
+    return tracker
+
+
+def get_highest_max_retention_count(
+    retention_tracker: dict[str, dict[str, int]],
+    cron_expressions: list[str],
+) -> Tuple[str, int]:
+    """
+    Get the highest maximum retention count.
+
+    Return
+        The highest maximum retention count configured between the provided cron
+        expressions, or 0 if the expression is not in the tracker.
+    """
+
+    maximum = 0
+    highest_exp = ""
+    for exp in cron_expressions:
+        if exp in retention_tracker and retention_tracker[exp]["max"] > maximum:
+            maximum = retention_tracker[exp]["max"]
+            highest_exp = exp
+    return (highest_exp, maximum)
+
+
+def clean_cron_expression(cron_expression: list[str]) -> str:
+    """
+    Clean a potentially bastardized cron expression.
+
+    Remove the sixth option, if it exists. Otherwise, just return the expression as-is.
+
+    Sample input: "* * 4 * * 7"
+    Sample output: "* * 4 * *"
+    """
+
+    parts = cron_expression.split()
+    if len(parts) == 6:
+        parts.pop()
+    return " ".join(parts).strip()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,0 +1,302 @@
+from datetime import datetime
+
+import pytest
+
+import blackbox.utils.rotation as rotation
+
+
+SAMPLE_DATETIME_1 = datetime.fromisoformat("2025-02-24 15:38:45.000265+00:00")
+SAMPLE_DATETIME_2 = datetime.fromisoformat("2025-01-05 10:18:36.000265+00:00")
+
+
+@pytest.fixture
+def mock_cron_expression_datetime_cases():
+    """Mock cases for cron expressions, datetime to test, and the expected value."""
+    return [
+        (
+            # 04:00 - 04:59
+            "* 4 * * *",
+            datetime(year=2025, month=2, day=21,
+                     hour=4, minute=25, second=35, microsecond=1),
+            True,
+        ),
+        (
+            # :30
+            "30 * * * *",
+            datetime(year=2012, month=7, day=6,
+                     hour=9, minute=25, second=35, microsecond=1),
+            False,
+        ),
+        (
+            # :30
+            "30 * * * *",
+            datetime(year=2012, month=7, day=6,
+                     hour=9, minute=30, second=35, microsecond=1),
+            True,
+        ),
+        (
+            # 1st day of any month
+            "* * 1 * *",
+            datetime(year=2012, month=7, day=6,
+                     hour=9, minute=30, second=35, microsecond=1),
+            False,
+        ),
+        (
+            # 2nd month (February)
+            "* * * 2 *",
+            datetime(year=2022, month=2, day=16,
+                     hour=12, minute=30, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # 2nd month (February)
+            "* * * 2 *",
+            datetime(year=2022, month=5, day=16,
+                     hour=12, minute=30, second=45, microsecond=17),
+            False,
+        ),
+        (
+            # Any time on a Sunday
+            "* * * * 7",
+            datetime(year=2025, month=2, day=23,  # Sunday
+                     hour=12, minute=30, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # Any time on a Sunday
+            "* * * * 7",
+            datetime(year=2025, month=2, day=22,  # Saturday
+                     hour=12, minute=30, second=45, microsecond=17),
+            False,
+        ),
+        (
+            # 03:12 on December 4th
+            "12 3 4 12 *",
+            datetime(year=2025, month=2, day=22,
+                     hour=12, minute=30, second=45, microsecond=17),
+            False,
+        ),
+        (
+            # 03:12 on December 4th
+            "12 3 4 12 *",
+            datetime(year=2025, month=12, day=4,
+                     hour=3, minute=12, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # 1st or 2nd of any month at either 02:05 or 02:10 AM
+            "5,10 2 1,2 * *",
+            datetime(year=2025, month=12, day=4,
+                     hour=3, minute=12, second=45, microsecond=17),
+            False,
+        ),
+        (
+            # 1st or 2nd of any month at either 02:05 or 02:10 AM
+            "5,10 2 1,2 * *",
+            datetime(year=2025, month=12, day=2,
+                     hour=2, minute=5, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # Any Sunday between 00:00 and 06:59
+            "* 0-6 * * 0",
+            datetime(year=2025, month=2, day=23,
+                     hour=3, minute=12, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # Any Sunday between 00:00 and 06:59
+            "* 0-6 * * 0",
+            datetime(year=2025, month=2, day=23,
+                     hour=6, minute=12, second=45, microsecond=17),
+            True,
+        ),
+        (
+            # Any Sunday between 00:00 and 06:59
+            "* 0-6 * * 0",
+            datetime(year=2025, month=2, day=23,
+                     hour=7, minute=0, second=45, microsecond=17),
+            False,
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_cron_expressions_to_clean():
+    """Mock cases for cron expressions to clean."""
+    return [
+        ("* * * 2 * *", "* * * 2 *"),
+        ("25 10 * * * *", "25 10 * * *"),
+        ("* 11 * * 1 1", "* 11 * * 1"),
+        ("2 4 5 7 4 0", "2 4 5 7 4"),
+        ("* 3/2 1,3,4 5-9 * 5", "* 3/2 1,3,4 5-9 *")
+    ]
+
+
+@pytest.fixture
+def mock_rotation_strategies():
+    """Mock rotation strategies config."""
+    return [
+        "* * * 2 * *",
+        "25 10 * * * *",
+        "* 11 * * 1 1",
+        "2 4 5 7 4 0",
+        "* 3/2 1,3,4 5-9 * 5",
+        "1 1 3 4 7",
+        "* * * * *",
+    ]
+
+
+@pytest.fixture
+def mock_cron_expressions():
+    """Mock cron expressions against which to match a provided datetime."""
+    return [
+        "* * * 2 *",  # Any time in February
+        "38 15 * * *",  # 15:38 UTC, any day, any month
+        "* 11 * * 1",  # 11:00 - 11:59 UTC, Mondays, any month
+        "26 * 4 * *",  # The 26th minute of any hour, on the 4th of any month
+        "* * * * 1",  # Any time on any Monday
+        "12 4 5 2 7",  # 4:12, on the 5th of February, if it's a Sunday
+        "* 0/3 * * *",  # Every 3rd hour from 0-23, any minute, any day, any month
+        "38 15 24 2 1",  # 15:38 UTC, on the 24th of February, if it's a Monday
+        "* * 19 * 7",  # Any time on the 19th day of any month, if it's a Sunday
+        "* 10-15 * 2 *",  # Any minute in any hour from 10 through 15 in February
+        "* * 2,24,28 1,2,3 *",  # Any time in Jan/Feb/Mar, on the 2nd/24th/28th day
+        "* * 2,28 1,2,3 *",  # Any time in Jan/Feb/Mar, on the 2nd/28th day
+        "* * * * *",  # Literally any time
+    ]
+
+
+@pytest.fixture
+def mock_retention_tracker():
+    """Mock a retention tracker."""
+    return {
+        "* * * 2 *": {
+            "num_retained": 0,
+            "max": 999999,
+        },
+        "25 10 * * *": {
+            "num_retained": 0,
+            "max": 999999,
+        },
+        "* 11 * * 1": {
+            "num_retained": 0,
+            "max": 1,
+        },
+        "2 4 5 7 4": {
+            "num_retained": 0,
+            "max": 0,
+        },
+        "* 3/2 1,3,4 5-9 *": {
+            "num_retained": 0,
+            "max": 5,
+        },
+        "1 1 3 4 7": {
+            "num_retained": 0,
+            "max": 999999,
+        },
+        "* * * * *": {
+            "num_retained": 0,
+            "max": 999999,
+        },
+    }
+
+
+def test_cron_datetime_matcher_works(mock_cron_expression_datetime_cases):
+    """Test that the matches_cron helper accurately matches datetimes to cron
+    expressions."""
+    for dt in mock_cron_expression_datetime_cases:
+        assert rotation.matches_cron(cron_expression=dt[0], dt=dt[1]) == dt[2]
+
+
+def test_clean_cron_expression(mock_cron_expressions_to_clean):
+    """Test that cron expressions are properly cleaned to retain the first 5 values."""
+    for exp in mock_cron_expressions_to_clean:
+        assert rotation.clean_cron_expression(exp[0]) == exp[1]
+
+
+def test_batch_cron_datetime_matcher_works(mock_cron_expressions):
+    """Test that the batch cron datetime matcher is accurate."""
+    matches = rotation.matches_crons(
+        cron_expressions=mock_cron_expressions,
+        dt=SAMPLE_DATETIME_1,
+    )
+    assert matches == [
+        "* * * 2 *",  # Any time in February
+        "38 15 * * *",  # 15:38 UTC, any day, any month
+        "* * * * 1",  # Any time on any Monday
+        "* 0/3 * * *",  # Every 3rd hour from 0-23, any minute, any day, any month
+        "38 15 24 2 1",  # 15:38 UTC, on the 24th of February, if it's a Monday
+        "* 10-15 * 2 *",  # Any minute in any hour from 10 through 15 in February
+        "* * 2,24,28 1,2,3 *",  # Any time in Jan/Feb/Mar, on the 2nd/24th/28th day
+        "* * * * *",  # Literally any time
+    ]
+
+
+def test_datetime_field_matching():
+    """Test that matching different fields of a datetime accurately resolve to True or
+    False when matched against the corresponding part of a cron expression."""
+    # Test that matching returns True when expected
+    exp = "38 15 24 2 1"
+    exp_parts = exp.split()
+    assert rotation.match_field(value=SAMPLE_DATETIME_1.minute, field=exp_parts[0])
+    assert rotation.match_field(value=SAMPLE_DATETIME_1.hour, field=exp_parts[1])
+    assert rotation.match_field(value=SAMPLE_DATETIME_1.day, field=exp_parts[2])
+    assert rotation.match_field(value=SAMPLE_DATETIME_1.month, field=exp_parts[3])
+    assert rotation.match_field(
+        value=SAMPLE_DATETIME_1.isoweekday(),
+        field=exp_parts[4],
+        is_weekday=True,
+    )
+    # Test that matching returns False when expected
+    assert not rotation.match_field(
+        value=SAMPLE_DATETIME_2.minute,
+        field=exp_parts[0],
+    )
+    assert not rotation.match_field(
+        value=SAMPLE_DATETIME_2.hour,
+        field=exp_parts[1],
+    )
+    assert not rotation.match_field(
+        value=SAMPLE_DATETIME_2.day,
+        field=exp_parts[2],
+    )
+    assert not rotation.match_field(
+        value=SAMPLE_DATETIME_2.month,
+        field=exp_parts[3],
+    )
+    assert not rotation.match_field(
+        value=SAMPLE_DATETIME_2.isoweekday(),
+        field=exp_parts[4],
+        is_weekday=True,
+    )
+
+
+def test_date_within_retention_days():
+    """Test that `within_retention_days` correctly returns whether a provided datetime
+    is within the provided number of days ago."""
+    retention_days = 7
+    assert rotation.within_retention_days(
+        days=retention_days,
+        dt=SAMPLE_DATETIME_1,
+    )
+    assert not rotation.within_retention_days(
+        days=retention_days,
+        dt=SAMPLE_DATETIME_2,
+    )
+
+
+def test_construct_retention_tracker(mock_rotation_strategies, mock_retention_tracker):
+    """Test that the retention tracker matches the expected format."""
+    assert rotation.construct_retention_tracker(
+        cron_expressions=mock_rotation_strategies,
+    ) == mock_retention_tracker
+
+
+def test_correct_highest_max_retention_count(mock_retention_tracker):
+    """Test that the expression with the highest max is correctly returned."""
+    highest_max_exp = rotation.get_highest_max_retention_count(
+        retention_tracker=mock_retention_tracker,
+        cron_expressions=["* 3/2 1,3,4 5-9 *", "* 11 * * 1"],
+    )
+    assert highest_max_exp == ("* 3/2 1,3,4 5-9 *", 5)

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -320,35 +320,24 @@ def test_datetime_field_matching():
     # Test that matching returns True when expected
     exp = "38 15 24 2 1"
     exp_parts = exp.split()
-    assert rotation.match_field(value=SAMPLE_DATETIME_1.minute, field=exp_parts[0])
-    assert rotation.match_field(value=SAMPLE_DATETIME_1.hour, field=exp_parts[1])
-    assert rotation.match_field(value=SAMPLE_DATETIME_1.day, field=exp_parts[2])
-    assert rotation.match_field(value=SAMPLE_DATETIME_1.month, field=exp_parts[3])
+    assert rotation.match_field(SAMPLE_DATETIME_1.minute, exp_parts[0])
+    assert rotation.match_field(SAMPLE_DATETIME_1.hour, exp_parts[1])
+    assert rotation.match_field(SAMPLE_DATETIME_1.day, exp_parts[2])
+    assert rotation.match_field(SAMPLE_DATETIME_1.month, exp_parts[3])
     assert rotation.match_field(
-        value=SAMPLE_DATETIME_1.isoweekday(),
-        field=exp_parts[4],
+        SAMPLE_DATETIME_1.isoweekday(),
+        exp_parts[4],
         is_weekday=True,
     )
+
     # Test that matching returns False when expected
+    assert not rotation.match_field(SAMPLE_DATETIME_2.minute, exp_parts[0])
+    assert not rotation.match_field(SAMPLE_DATETIME_2.hour, exp_parts[1])
+    assert not rotation.match_field(SAMPLE_DATETIME_2.day, exp_parts[2])
+    assert not rotation.match_field(SAMPLE_DATETIME_2.month, exp_parts[3])
     assert not rotation.match_field(
-        value=SAMPLE_DATETIME_2.minute,
-        field=exp_parts[0],
-    )
-    assert not rotation.match_field(
-        value=SAMPLE_DATETIME_2.hour,
-        field=exp_parts[1],
-    )
-    assert not rotation.match_field(
-        value=SAMPLE_DATETIME_2.day,
-        field=exp_parts[2],
-    )
-    assert not rotation.match_field(
-        value=SAMPLE_DATETIME_2.month,
-        field=exp_parts[3],
-    )
-    assert not rotation.match_field(
-        value=SAMPLE_DATETIME_2.isoweekday(),
-        field=exp_parts[4],
+        SAMPLE_DATETIME_2.isoweekday(),
+        exp_parts[4],
         is_weekday=True,
     )
 


### PR DESCRIPTION
## 📃 Overview

Implement support for multiple rotation strategies using ✨ enhanced ✨ cron expressions.

The sixth parameter represents the _number_ of backups matching this condition to keep. Omitting this or setting it to `*` will retain _all_ matching backups.

If `retention_days` is configured, _all_ backups created within this retention window will be retained, regardless of configured rotation strategies.

Two new methods were added into the storage handler base class: `_do_rotate()` and `_delete_backup()` (abstract). The former outsources all the rotation logic to the base class. The latter will typically be a one-liner handling the storange-handler-specific logic for deleting a backup file using its identifier. This keeps implementing new storage handlers as simple as before - and perhaps even makes it a little bit simpler.

## 👀 Examples

`* * 1 * * 5` - Retain the most recent 5 backups created on the first of any month.
`* * * * * 10` - Retain the most recent 5 backups, created any time.
`30,31,55 0-12 1-15 */2 1 *` - Retain any backups created at minute 30, 31, and 55 past every hour from 0 through 12 on every day-of-month from 1 through 15 and on Monday in every 2nd month 🫨

See the updated `README.md` for more details and examples.

## ✅ Tests

Tests were written and pass for all new helpers in `blackbox/utils/rotation.py`. 

---

Resolves #158 