### PR TITLE
Fix CI cascade when publishing releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           file_pattern: pyproject.toml
-          commit_message: Bump version to ${{ github.event.release.tag_name }}
+          commit_message: Bump version to ${{ github.event.release.tag_name }} [skip ci]
 
   publish-to-pipy:
     name: Publish to pypi.org


### PR DESCRIPTION
When publishing a release, the following cascade occurs:
1. Release triggers `publish.yaml` workflow ✅
2. `publish.yaml` bumps version and commits to main
3. That commit triggers `build_and_push.yaml` workflow 🔄 (duplicate)
4. That commit also triggers `tests.yaml` workflow 🔄 (duplicate) 
5. Plus `publish.yaml` has its own Docker build job

Adding `[skip ci]` to the version bump commit prevents it from triggering the other workflows.