### PR TITLE
🔧 chore: switch PyPI release to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,41 +5,24 @@ on:
     types: [published]
 
 jobs:
-  bump-pyproject-version:
-    name: Bump pyproject version
+  release:
+    name: Bump version, build, and publish
     runs-on: ubuntu-latest
+    environment: pypi
+
+    # `id-token: write` lets the publish step mint the OIDC token PyPI
+    # trusts for this repo + workflow + environment. `contents: write`
+    # is for the auto-commit that pushes the version bump back to main.
+    permissions:
+      id-token: write
+      contents: write
+
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:
           ref: main
           ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Bump the version
-        run: |
-          # Strip any leading 'v' from the tag (PEP 440 doesn't allow it).
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          uv version "$VERSION"
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: pyproject.toml uv.lock
-          commit_message: "Bump version to ${{ github.event.release.tag_name }} [skip ci]"
-
-  publish-to-pypi:
-    name: Publish to pypi.org
-    runs-on: ubuntu-latest
-    needs: bump-pyproject-version
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -50,18 +33,29 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Bump the version
+        run: |
+          # Strip any leading 'v' from the tag (PEP 440 doesn't allow it).
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          uv version "$VERSION"
+
       - name: Build distributions
         run: uv build
 
-      - name: Publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
+      - name: Commit version bump
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: pyproject.toml uv.lock
+          commit_message: "Bump version to ${{ github.event.release.tag_name }} [skip ci]"
+
+      - name: Publish to PyPI via Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   build-and-push-on-release:
     name: Build and push to DockerHub
     runs-on: ubuntu-latest
-    needs: publish-to-pypi
+    needs: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
> [!WARNING]
> Once a release run succeeds end-to-end, the \`PYPI_TOKEN\` secret can be deleted from repo settings. Until then, leave it in place as a safety net.

## What

Migrates `publish.yaml` off the long-lived `PYPI_TOKEN` secret and onto **PyPI Trusted Publishing** (OIDC). Mirrors the same change in [django-simple-bulma#134](https://github.com/lemonsaurus/django-simple-bulma/pull/134).

## Why

| before | after |
| --- | --- |
| `uv publish` with `UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}` | `pypa/gh-action-pypi-publish@release/v1` mints a short-lived OIDC token at run time |
| Token has to be rotated manually if it ever leaks | No token to leak; trust is scoped to repo + workflow + environment by PyPI |
| Two PyPI jobs, two checkouts | One `release` job |

The PyPI side is already configured (Trusted Publisher: lemonsaurus / blackbox / publish.yaml / environment `pypi`).

## What changed in the workflow

- Collapsed `bump-pyproject-version` and `publish-to-pypi` into a single `release` job.
- Added `environment: pypi` and `permissions: id-token: write` (required for OIDC) plus `contents: write` for the version-bump auto-commit.
- Build still happens via `uv build` (inherited from #198); `pypa/gh-action-pypi-publish` reads the resulting `dist/`.
- The DockerHub `build-and-push-on-release` job is untouched. DockerHub credentials don't have an OIDC equivalent we use, so the `DOCKERHUB_TOKEN` secret stays.