### PR TITLE
🐛 fix: unbreak DockerHub release + add image smoke test

### DIFF
--- a/.github/workflows/docker_smoke.yaml
+++ b/.github/workflows/docker_smoke.yaml
@@ -16,6 +16,9 @@ on:
       - 'uv.lock'
       - '.github/workflows/docker_smoke.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Build and verify backup tools

--- a/.github/workflows/docker_smoke.yaml
+++ b/.github/workflows/docker_smoke.yaml
@@ -1,0 +1,50 @@
+name: Docker Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - 'docker/Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/docker_smoke.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/Dockerfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/docker_smoke.yaml'
+
+jobs:
+  smoke:
+    name: Build and verify backup tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (amd64, load to local Docker)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: false
+          load: true
+          tags: blackbox:smoke
+
+      - name: Verify backup tools are installed and runnable
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh blackbox:smoke -c '
+            set -e
+            echo "blackbox:" && blackbox --help >/dev/null && echo "  ok"
+            echo "mongodump:" && mongodump --version | head -1
+            echo "mongorestore:" && mongorestore --version | head -1
+            echo "pg_dump:" && pg_dump --version
+            echo "mariadb-dump:" && mariadb-dump --version
+            echo "redis-cli:" && redis-cli --version
+          '

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,8 @@ RUN architecture="x86_64"; \
         arm64|aarch64) architecture="arm64" ;; \
     esac; \
     wget -q "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2404-${architecture}-100.12.2.deb" -O /tmp/mongo-tools.deb && \
-    apt-get install -y /tmp/mongo-tools.deb && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends /tmp/mongo-tools.deb && \
     rm /tmp/mongo-tools.deb && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Two release attempts on `main` (commits `3a14454` and the v3.0.0 tag) failed at the `mongodb-database-tools` install step with every krb5/comerr dependency reported as \"not installable\" on Debian 13 (trixie). This PR fixes this, and adds some new smoke testing to ensure it's not possible to get into this situation again.

## 🐢 What gets added
- `apt-get update` at the start of the mongo-tools layer so dependency resolution actually has data to work with.
- New `docker_smoke.yaml` workflow that builds the image on every PR touching `docker/Dockerfile`, `pyproject.toml`, `uv.lock`, or itself.